### PR TITLE
feat(agent): intra-run tool-output trimmer + fix read-only co-call metric

### DIFF
--- a/apps/server/agent/core/metrics.py
+++ b/apps/server/agent/core/metrics.py
@@ -47,6 +47,12 @@ TOOL_CALLS_ERRORS: Final[str] = "tool.calls.errors"
 TOOL_READONLY_COCALL_TOTAL: Final[str] = "tool.readonly.cocall.total"
 TOOL_READONLY_TURNS_TOTAL: Final[str] = "tool.readonly.turns.total"
 
+# Intra-run tool-output trimming (call_model_input_filter). Counts how many
+# stale tool outputs were previewed and how many characters were reclaimed
+# from the model input across the lifetime of the process.
+TOOL_OUTPUT_TRIMMED_TOTAL: Final[str] = "tool.output.trimmed.total"
+TOOL_OUTPUT_TRIMMED_CHARS: Final[str] = "tool.output.trimmed.chars"
+
 # Context metrics
 CONTEXT_TOKENS_TOTAL: Final[str] = "context.tokens.total"
 CONTEXT_ITEMS_COUNT: Final[str] = "context.items.count"

--- a/apps/server/agent/openai_agents/intra_run_trimmer.py
+++ b/apps/server/agent/openai_agents/intra_run_trimmer.py
@@ -1,0 +1,173 @@
+"""Intra-run tool-output trimmer (a RunConfig.call_model_input_filter).
+
+Why a custom filter instead of agents.extensions.ToolOutputTrimmer:
+
+The stock SDK trimmer only trims tool outputs that appear *before* the
+Nth-from-last ``user`` message. In this project that is a guaranteed no-op:
+``normalize_messages_for_openai_agents`` (runner.py) strips all tool blocks from
+persisted history to plain text, so cross-request tool outputs are never
+``function_call_output`` items; and intra-run tool outputs always appear *after*
+the current turn's user message, so they are always in the stock trimmer's
+"recent" (never-trimmed) zone. Verified empirically: the stock trimmer reclaims
+0 chars for every ``recent_turns`` value here.
+
+This filter instead trims by *intra-run recency*: within the input list for a
+single model call it keeps the most recent ``keep_recent`` trimmable tool
+outputs at full fidelity and replaces earlier oversized ones (from the same run)
+with a compact preview. Bulky read-only retrieval outputs (``query_files`` /
+``hybrid_search``) accumulate across a multi-tool run and dominate later model
+calls; previewing the stale ones reclaims that budget while keeping the freshest
+results intact.
+
+Control-flow tool outputs (``handoff_to_agent`` / ``request_clarification``) are
+never trimmed: they are outside the allowlist, AND the runner reads their
+payload from the live SDK run-item, not from this filtered model input — so the
+filter cannot affect control flow even in principle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from agents.run_config import CallModelData, ModelInputData
+
+logger = get_logger(__name__)
+
+# Read-only retrieval tools whose outputs are bulky and safe to preview once stale.
+DEFAULT_TRIMMABLE_TOOLS: frozenset[str] = frozenset({"query_files", "hybrid_search"})
+
+
+class IntraRunToolOutputTrimmer:
+    """Preview stale intra-run tool outputs before each model call.
+
+    Args:
+        keep_recent: Number of most-recent trimmable tool outputs kept at full
+            fidelity. Older trimmable outputs in the same run become candidates
+            for previewing. Defaults to 2.
+        max_output_chars: Only outputs longer than this are previewed. Defaults
+            to 2000 (well above a one-line result, below a typical search dump).
+        preview_chars: How many leading characters of the original output to keep
+            in the preview. Defaults to 400.
+        trimmable_tools: Tool names whose outputs may be previewed. Defaults to
+            ``{"query_files", "hybrid_search"}``. Control-flow tools are never
+            included.
+    """
+
+    def __init__(
+        self,
+        *,
+        keep_recent: int = 2,
+        max_output_chars: int = 2000,
+        preview_chars: int = 400,
+        trimmable_tools: frozenset[str] | None = None,
+    ) -> None:
+        if keep_recent < 0:
+            raise ValueError(f"keep_recent must be >= 0, got {keep_recent}")
+        if max_output_chars < 1:
+            raise ValueError(f"max_output_chars must be >= 1, got {max_output_chars}")
+        if preview_chars < 0:
+            raise ValueError(f"preview_chars must be >= 0, got {preview_chars}")
+        self.keep_recent = keep_recent
+        self.max_output_chars = max_output_chars
+        self.preview_chars = preview_chars
+        self.trimmable_tools = (
+            DEFAULT_TRIMMABLE_TOOLS if trimmable_tools is None else frozenset(trimmable_tools)
+        )
+
+    def __call__(self, data: CallModelData[Any]) -> ModelInputData:
+        from agents.run_config import ModelInputData
+
+        model_data = data.model_data
+        items = model_data.input
+        if not items:
+            return model_data
+
+        call_id_to_name = self._build_call_id_to_name(items)
+
+        # Indices of trimmable function_call_output items, in input order.
+        trimmable_indices = [
+            i
+            for i, it in enumerate(items)
+            if self._is_trimmable_output(it, call_id_to_name)
+        ]
+
+        # Keep the most recent `keep_recent` trimmable outputs untouched.
+        if len(trimmable_indices) <= self.keep_recent:
+            return model_data
+        stale_cutoff = len(trimmable_indices) - self.keep_recent if self.keep_recent else len(trimmable_indices)
+        stale_indices = set(trimmable_indices[:stale_cutoff])
+
+        new_items: list[Any] = []
+        trimmed_count = 0
+        chars_saved = 0
+        for i, it in enumerate(items):
+            if i in stale_indices:
+                previewed, saved = self._preview_output(it)
+                if previewed is not None:
+                    new_items.append(previewed)
+                    trimmed_count += 1
+                    chars_saved += saved
+                    continue
+            new_items.append(it)
+
+        if trimmed_count:
+            self._record_metrics(trimmed_count, chars_saved)
+            logger.debug(
+                "IntraRunToolOutputTrimmer previewed %d stale tool output(s), saved ~%d chars",
+                trimmed_count,
+                chars_saved,
+            )
+
+        return ModelInputData(input=new_items, instructions=model_data.instructions)
+
+    def _build_call_id_to_name(self, items: list[Any]) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        for it in items:
+            if isinstance(it, dict) and it.get("type") == "function_call":
+                call_id = it.get("call_id") or it.get("id")
+                name = it.get("name")
+                if call_id and name:
+                    mapping[str(call_id)] = str(name)
+        return mapping
+
+    def _is_trimmable_output(self, item: Any, call_id_to_name: dict[str, str]) -> bool:
+        if not isinstance(item, dict) or item.get("type") != "function_call_output":
+            return False
+        call_id = str(item.get("call_id") or item.get("id") or "")
+        return call_id_to_name.get(call_id, "") in self.trimmable_tools
+
+    def _preview_output(self, item: dict[str, Any]) -> tuple[dict[str, Any] | None, int]:
+        output = item.get("output", "")
+        output_str = output if isinstance(output, str) else str(output)
+        original_len = len(output_str)
+        if original_len <= self.max_output_chars:
+            return None, 0
+
+        preview = output_str[: self.preview_chars]
+        summary = (
+            f"[Trimmed stale tool output — {original_len} chars → "
+            f"{self.preview_chars} char preview]\n{preview}..."
+        )
+        if len(summary) >= original_len:
+            return None, 0
+
+        previewed = dict(item)
+        previewed["output"] = summary
+        return previewed, original_len - len(summary)
+
+    def _record_metrics(self, trimmed_count: int, chars_saved: int) -> None:
+        try:
+            from agent.core.metrics import (
+                TOOL_OUTPUT_TRIMMED_CHARS,
+                TOOL_OUTPUT_TRIMMED_TOTAL,
+                get_metrics_collector,
+            )
+
+            mc = get_metrics_collector()
+            mc.increment_counter(TOOL_OUTPUT_TRIMMED_TOTAL, trimmed_count)
+            mc.increment_counter(TOOL_OUTPUT_TRIMMED_CHARS, chars_saved)
+        except Exception:  # metrics are best-effort; never break a model call
+            logger.debug("Failed to record tool-output-trim metrics", exc_info=True)

--- a/apps/server/agent/openai_agents/runner.py
+++ b/apps/server/agent/openai_agents/runner.py
@@ -307,6 +307,8 @@ async def run_openai_agents_streaming_agent(
         from agents import RunConfig, Runner, ToolExecutionConfig
         from agents.exceptions import MaxTurnsExceeded
 
+        from .intra_run_trimmer import IntraRunToolOutputTrimmer
+
         sdk_agent = _build_agent(agent_type, system_prompt)
         result = Runner.run_streamed(
             sdk_agent,
@@ -318,6 +320,12 @@ async def run_openai_agents_streaming_agent(
             # execution to preserve the previous sequential contract and avoid Session races.
             run_config=RunConfig(
                 tool_execution=ToolExecutionConfig(max_function_tool_concurrency=1),
+                # Preview stale intra-run retrieval outputs (query_files / hybrid_search)
+                # so a long multi-tool run doesn't re-send every bulky search dump on each
+                # subsequent model call. Keeps the freshest outputs full; control-flow tool
+                # outputs are never touched. See intra_run_trimmer for why the stock SDK
+                # ToolOutputTrimmer is a no-op for this project's history shape.
+                call_model_input_filter=IntraRunToolOutputTrimmer(),
             ),
         )
 
@@ -362,6 +370,13 @@ async def run_openai_agents_streaming_agent(
                         }
                     )
                     # Read-only co-call tracking: count read-only calls before outputs arrive.
+                    # A tool_called arriving after a turn's outputs starts a NEW turn, so
+                    # reset the per-turn tracking here (not in the tool_output block) — that
+                    # keeps the turn guard set for the whole turn and avoids counting every
+                    # tool_output as a separate turn.
+                    if _turn_has_output:
+                        _turn_has_output = False
+                        _turn_readonly_pending = 0
                     if tool_name in _READONLY_TOOLS:
                         _turn_readonly_pending += 1
                     yield StreamEvent(
@@ -375,6 +390,9 @@ async def run_openai_agents_streaming_agent(
                     )
                 elif event_name == "tool_output":
                     # First tool_output of this turn: flush the pending read-only count.
+                    # The guard stays set for the rest of the turn; the next tool_called
+                    # batch resets it. This counts each turn exactly once (the previous
+                    # in-block reset made it count every tool_output as a turn).
                     if not _turn_has_output:
                         _turn_has_output = True
                         from agent.core.metrics import (
@@ -386,9 +404,6 @@ async def run_openai_agents_streaming_agent(
                         _mc.increment_counter(TOOL_READONLY_TURNS_TOTAL)
                         if _turn_readonly_pending >= 2:
                             _mc.increment_counter(TOOL_READONLY_COCALL_TOTAL)
-                        # Reset for next turn (next batch of tool_called events).
-                        _turn_readonly_pending = 0
-                        _turn_has_output = False
                     call_id, result_text = _tool_output_payload(item)
                     tool_name = tool_names_by_call_id.get(call_id, "")
                     tool_input = tool_inputs_by_call_id.get(call_id, {})

--- a/apps/server/tests/test_agent/test_intra_run_trimmer.py
+++ b/apps/server/tests/test_agent/test_intra_run_trimmer.py
@@ -1,0 +1,151 @@
+"""Tests for the intra-run tool-output trimmer (call_model_input_filter)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents.run_config import CallModelData, ModelInputData
+
+from agent.core.metrics import (
+    TOOL_OUTPUT_TRIMMED_CHARS,
+    TOOL_OUTPUT_TRIMMED_TOTAL,
+    get_metrics_collector,
+    reset_metrics_collector,
+)
+from agent.openai_agents.intra_run_trimmer import IntraRunToolOutputTrimmer
+
+BIG = "X" * 5000  # well above the default 2000-char trim threshold
+SMALL = "ok"
+
+
+def _fc(call_id: str, name: str) -> dict[str, Any]:
+    return {"type": "function_call", "call_id": call_id, "name": name, "arguments": "{}"}
+
+
+def _fco(call_id: str, output: str) -> dict[str, Any]:
+    return {"type": "function_call_output", "call_id": call_id, "output": output}
+
+
+def _run(trimmer: IntraRunToolOutputTrimmer, items: list[dict[str, Any]]) -> list[Any]:
+    md = ModelInputData(input=[dict(it) for it in items], instructions=None)
+    data = CallModelData(model_data=md, agent=None, context=None)
+    return trimmer(data).input
+
+
+def _outputs(items: list[Any]) -> list[str]:
+    return [it["output"] for it in items if it.get("type") == "function_call_output"]
+
+
+def test_keeps_recent_trims_stale():
+    """With 3 big retrieval outputs and keep_recent=2, only the oldest is previewed."""
+    items = [
+        {"role": "user", "content": "do it"},
+        _fc("c1", "hybrid_search"), _fco("c1", BIG),
+        _fc("c2", "hybrid_search"), _fco("c2", BIG),
+        _fc("c3", "query_files"), _fco("c3", BIG),
+    ]
+    out = _run(IntraRunToolOutputTrimmer(keep_recent=2), items)
+    outs = _outputs(out)
+    assert outs[0].startswith("[Trimmed stale tool output")  # c1 previewed
+    assert outs[1] == BIG  # c2 kept full
+    assert outs[2] == BIG  # c3 kept full
+
+
+def test_conservative_below_keep_recent():
+    """With <= keep_recent trimmable outputs, nothing is trimmed."""
+    items = [
+        {"role": "user", "content": "do it"},
+        _fc("c1", "hybrid_search"), _fco("c1", BIG),
+        _fc("c2", "query_files"), _fco("c2", BIG),
+    ]
+    out = _run(IntraRunToolOutputTrimmer(keep_recent=2), items)
+    assert _outputs(out) == [BIG, BIG]
+
+
+def test_small_outputs_untouched():
+    """Outputs below max_output_chars are never previewed, even if stale."""
+    items = [
+        _fc("c1", "hybrid_search"), _fco("c1", SMALL),
+        _fc("c2", "hybrid_search"), _fco("c2", SMALL),
+        _fc("c3", "hybrid_search"), _fco("c3", SMALL),
+    ]
+    out = _run(IntraRunToolOutputTrimmer(keep_recent=1), items)
+    assert _outputs(out) == [SMALL, SMALL, SMALL]
+
+
+def test_excludes_non_allowlisted_tools():
+    """Control-flow / non-retrieval tool outputs are never trimmed."""
+    items = [
+        _fc("c1", "handoff_to_agent"), _fco("c1", BIG),
+        _fc("c2", "request_clarification"), _fco("c2", BIG),
+        _fc("c3", "create_file"), _fco("c3", BIG),
+    ]
+    out = _run(IntraRunToolOutputTrimmer(keep_recent=1), items)
+    assert _outputs(out) == [BIG, BIG, BIG]
+
+
+def test_only_stale_allowlisted_trimmed_mixed():
+    """A mix: only the stale allowlisted output is previewed; others untouched."""
+    items = [
+        _fc("c1", "hybrid_search"), _fco("c1", BIG),   # stale allowlisted -> trimmed
+        _fc("c2", "handoff_to_agent"), _fco("c2", BIG),  # excluded -> full
+        _fc("c3", "query_files"), _fco("c3", BIG),     # recent allowlisted -> full
+    ]
+    out = _run(IntraRunToolOutputTrimmer(keep_recent=1), items)
+    outs = _outputs(out)
+    assert outs[0].startswith("[Trimmed stale tool output")
+    assert outs[1] == BIG
+    assert outs[2] == BIG
+
+
+def test_empty_input_returns_unchanged():
+    md = ModelInputData(input=[], instructions=None)
+    data = CallModelData(model_data=md, agent=None, context=None)
+    assert IntraRunToolOutputTrimmer()(data).input == []
+
+
+def test_does_not_mutate_original_items():
+    original = [
+        _fc("c1", "hybrid_search"), _fco("c1", BIG),
+        _fc("c2", "hybrid_search"), _fco("c2", BIG),
+        _fc("c3", "hybrid_search"), _fco("c3", BIG),
+    ]
+    snapshot = [dict(it) for it in original]
+    md = ModelInputData(input=original, instructions=None)
+    IntraRunToolOutputTrimmer(keep_recent=2)(CallModelData(model_data=md, agent=None, context=None))
+    assert original == snapshot  # filter must not mutate the caller's items
+
+
+def test_metrics_recorded_on_trim():
+    reset_metrics_collector()
+    items = [
+        _fc("c1", "hybrid_search"), _fco("c1", BIG),
+        _fc("c2", "hybrid_search"), _fco("c2", BIG),
+        _fc("c3", "hybrid_search"), _fco("c3", BIG),
+    ]
+    _run(IntraRunToolOutputTrimmer(keep_recent=2), items)
+    counters = get_metrics_collector().get_all_metrics()["counters"]
+    assert counters[TOOL_OUTPUT_TRIMMED_TOTAL]["value"] == 1
+    assert counters[TOOL_OUTPUT_TRIMMED_CHARS]["value"] > 0
+
+
+def test_no_metrics_when_nothing_trimmed():
+    reset_metrics_collector()
+    items = [_fc("c1", "hybrid_search"), _fco("c1", BIG)]
+    _run(IntraRunToolOutputTrimmer(keep_recent=2), items)
+    counters = get_metrics_collector().get_all_metrics()["counters"]
+    assert TOOL_OUTPUT_TRIMMED_TOTAL not in counters
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"keep_recent": -1},
+        {"max_output_chars": 0},
+        {"preview_chars": -1},
+    ],
+)
+def test_invalid_config_rejected(kwargs):
+    with pytest.raises(ValueError):
+        IntraRunToolOutputTrimmer(**kwargs)

--- a/apps/server/tests/test_agent/test_openai_agents_adapter.py
+++ b/apps/server/tests/test_agent/test_openai_agents_adapter.py
@@ -357,3 +357,96 @@ def test_normalize_omits_tool_use_and_tool_result_blocks():
     blob = str(messages)
     assert "create_file" not in blob and "secret" not in blob
     assert "工具调用" not in blob and "工具结果" not in blob
+
+
+def _called(name, call_id):
+    return SimpleNamespace(
+        type="run_item_stream_event",
+        name="tool_called",
+        item=SimpleNamespace(
+            raw_item={"name": name, "call_id": call_id, "arguments": "{}"}
+        ),
+    )
+
+
+def _output(call_id, text="ok"):
+    return SimpleNamespace(
+        type="run_item_stream_event",
+        name="tool_output",
+        item=SimpleNamespace(raw_item={"call_id": call_id}, output=text),
+    )
+
+
+async def test_runner_wires_intra_run_trimmer_into_run_config():
+    """The intra-run tool-output trimmer is attached as the model-input filter."""
+    from agent.openai_agents.intra_run_trimmer import IntraRunToolOutputTrimmer
+    from agent.openai_agents.runner import run_openai_agents_streaming_agent
+
+    class FakeResult:
+        raw_responses = []
+
+        def cancel(self, mode="immediate"):
+            pass
+
+        async def stream_events(self):
+            if False:  # empty stream
+                yield
+
+    state = {"user_message": "hi", "messages": [], "system_prompt": "base"}
+    with (
+        patch("agent.openai_agents.runner._build_agent", return_value=object()),
+        patch("agents.Runner.run_streamed", return_value=FakeResult()) as mock_run,
+    ):
+        _ = [
+            event
+            async for event in run_openai_agents_streaming_agent(
+                state=state, agent_type="writer", system_prompt="system"
+            )
+        ]
+
+    run_config = mock_run.call_args.kwargs["run_config"]
+    assert isinstance(run_config.call_model_input_filter, IntraRunToolOutputTrimmer)
+    assert run_config.tool_execution.max_function_tool_concurrency == 1
+
+
+async def test_readonly_cocall_metric_counts_each_turn_once():
+    """Regression lock: the read-only co-call metric counts each turn once, not per output."""
+    from agent.core.metrics import (
+        TOOL_READONLY_COCALL_TOTAL,
+        TOOL_READONLY_TURNS_TOTAL,
+        get_metrics_collector,
+    )
+    from agent.openai_agents.runner import run_openai_agents_streaming_agent
+
+    class FakeResult:
+        raw_responses = []
+
+        def cancel(self, mode="immediate"):
+            pass
+
+        async def stream_events(self):
+            # Turn 1: two read-only calls then their two outputs -> ONE turn, ONE co-call.
+            yield _called("hybrid_search", "c1")
+            yield _called("query_files", "c2")
+            yield _output("c1")
+            yield _output("c2")
+            # Turn 2: a single non-read-only call -> ONE turn, NO co-call.
+            yield _called("create_file", "c3")
+            yield _output("c3")
+
+    state = {"user_message": "x", "messages": [], "system_prompt": "base"}
+    with (
+        patch("agent.openai_agents.runner._build_agent", return_value=object()),
+        patch("agents.Runner.run_streamed", return_value=FakeResult()),
+    ):
+        _ = [
+            event
+            async for event in run_openai_agents_streaming_agent(
+                state=state, agent_type="writer", system_prompt="system"
+            )
+        ]
+
+    counters = get_metrics_collector().get_all_metrics()["counters"]
+    # Pre-fix bug: TURNS counted every tool_output (would be 3). Correct is 2 turns.
+    assert counters[TOOL_READONLY_TURNS_TOTAL]["value"] == 2
+    assert counters[TOOL_READONLY_COCALL_TOTAL]["value"] == 1


### PR DESCRIPTION
**Stacked on #1 (`agent-core-release`).**

The stock `agents.extensions.ToolOutputTrimmer` is a **verified no-op** here: history is stripped to text before the SDK sees it, and intra-run tool outputs always sit *after* the current user message, so they never enter the stock trimmer's "old" zone (empirically trims 0 chars at every `recent_turns`). Replace it with a custom filter that trims by **intra-run recency**.

## Changes
- `intra_run_trimmer.py` — `IntraRunToolOutputTrimmer` keeps the most recent `keep_recent` (default 2) trimmable tool outputs full and previews earlier oversized `query_files`/`hybrid_search` outputs in the same run. Control-flow tools (`handoff_to_agent`/`request_clarification`) excluded. **Ships ON, no flag**, conservative defaults.
- `runner.py` — wire into `RunConfig.call_model_input_filter`; **fix the read-only co-call metric** (the per-turn guard reset lived inside the `tool_output` block, so `TOOL_READONLY_TURNS_TOTAL` counted every output as a turn — moved to the next `tool_called` batch).
- `metrics.py` — `TOOL_OUTPUT_TRIMMED_TOTAL` / `_CHARS` counters.

## Tests
12 trimmer unit tests + RunConfig-wiring assertion + a metric regression lock (2 outputs in one turn ⇒ 1 turn, not 3). Full agent suite **785 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)