### PR TITLE
feat(agent): make parallel execution and steering usable end-to-end

### DIFF
--- a/apps/server/agent/core/message_manager.py
+++ b/apps/server/agent/core/message_manager.py
@@ -65,6 +65,7 @@ class MessageManager:
         assistant_stop_reason: str | None = None,
         assistant_usage: dict[str, Any] | None = None,
         assistant_status_cards: list[dict[str, Any]] | None = None,
+        steering_messages: list[str] | None = None,
     ) -> str | None:
         """
         Save messages to chat history.
@@ -78,6 +79,8 @@ class MessageManager:
             reasoning_content: Thinking/reasoning content from the model
             assistant_stop_reason: Model stop reason from MESSAGE_END
             assistant_usage: Model usage payload from MESSAGE_END
+            steering_messages: Steering messages injected mid-run, persisted as
+                their own user-role turns so they survive into later requests
 
         Returns:
             Persisted assistant message ID when history save succeeds
@@ -93,6 +96,7 @@ class MessageManager:
                 assistant_stop_reason,
                 assistant_usage,
                 assistant_status_cards,
+                steering_messages,
             )
         return self._save_messages_with_session(
             session,
@@ -104,6 +108,7 @@ class MessageManager:
             assistant_stop_reason,
             assistant_usage,
             assistant_status_cards,
+            steering_messages,
         )
 
     def _should_offload_session_work(self, session: Session) -> bool:
@@ -122,6 +127,7 @@ class MessageManager:
         assistant_stop_reason: str | None = None,
         assistant_usage: dict[str, Any] | None = None,
         assistant_status_cards: list[dict[str, Any]] | None = None,
+        steering_messages: list[str] | None = None,
     ) -> str | None:
         """Persist chat history with a fresh sync DB session."""
         with create_session() as session:
@@ -135,6 +141,7 @@ class MessageManager:
                 assistant_stop_reason,
                 assistant_usage,
                 assistant_status_cards,
+                steering_messages,
             )
 
     def _save_messages_with_session(
@@ -148,6 +155,7 @@ class MessageManager:
         assistant_stop_reason: str | None = None,
         assistant_usage: dict[str, Any] | None = None,
         assistant_status_cards: list[dict[str, Any]] | None = None,
+        steering_messages: list[str] | None = None,
     ) -> str | None:
         """Core chat-history persistence logic using the provided session."""
         from models import ChatMessage, ChatSession
@@ -246,6 +254,23 @@ class MessageManager:
             )
             session.add(user_chat_message)
 
+            # Persist steering messages injected mid-run as their own user-role
+            # turns (between the original user message and the assistant reply),
+            # so node-boundary steering survives into the next request's history
+            # instead of being dropped when the stream ends.
+            steering_saved = 0
+            for steering_text in steering_messages or []:
+                if not isinstance(steering_text, str) or not steering_text.strip():
+                    continue
+                session.add(
+                    ChatMessage(
+                        session_id=chat_session.id,
+                        role="user",
+                        content=steering_text,
+                    )
+                )
+                steering_saved += 1
+
             # Save assistant message
             tool_calls_json = self._serialize_tool_calls(tool_calls)
             assistant_metadata_json = self._serialize_message_metadata(
@@ -264,7 +289,7 @@ class MessageManager:
             )
             session.add(assistant_chat_message)
 
-            chat_session.message_count += 2
+            chat_session.message_count += 2 + steering_saved
             chat_session.updated_at = utcnow()
             session.commit()
 

--- a/apps/server/agent/core/progress_channel.py
+++ b/apps/server/agent/core/progress_channel.py
@@ -1,0 +1,61 @@
+"""In-band progress channel for tool calls that want to stream live sub-events.
+
+The openai-agents SDK owns the model+tool loop: while a tool's ``on_invoke_tool``
+callback runs, the consumer of ``Runner.run_streamed().stream_events()`` is parked
+awaiting the next SDK event, so a long-running tool (e.g. ``parallel_execute``)
+cannot surface intermediate progress through the normal SDK event flow.
+
+This module provides a tiny context-local emitter the runner installs before
+starting the SDK run. A tool executing inside the SDK background task can then
+call :func:`emit_progress` to hand a pre-built workflow/SSE event back to the
+runner, which interleaves it into the outbound stream.
+
+Design notes:
+- The channel holds a *callable* (not a queue) so the runner decides how to
+  enqueue (it tags the event for its own merge loop). This keeps the channel
+  generic and free of any runner/SDK imports.
+- ``contextvars`` propagate into the SDK background task because
+  ``asyncio.create_task`` (used by ``Runner.run_streamed``) copies the current
+  context at creation time. The runner installs the emitter *before* starting
+  the run, so the tool's context copy sees it.
+- :func:`emit_progress` never raises and is a no-op when no channel is active
+  (e.g. tools invoked directly from unit tests), so callers can emit freely
+  without guarding.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Any, Callable
+
+# A context-local "emit this event" callback installed by the runner.
+_progress_emitter: contextvars.ContextVar[Callable[[Any], None] | None] = (
+    contextvars.ContextVar("agent_progress_emitter", default=None)
+)
+
+
+def set_progress_emitter(emitter: Callable[[Any], None]) -> contextvars.Token:
+    """Install the progress emitter for the current context. Returns a reset token."""
+    return _progress_emitter.set(emitter)
+
+
+def reset_progress_emitter(token: contextvars.Token) -> None:
+    """Restore the previous emitter using the token from :func:`set_progress_emitter`."""
+    _progress_emitter.reset(token)
+
+
+def emit_progress(event: Any) -> bool:
+    """Hand a pre-built event to the active progress channel, if any.
+
+    Safe to call from anywhere: returns ``False`` (no-op) when no channel is
+    installed, and swallows any delivery error so progress emission can never
+    break the tool it is reporting on.
+    """
+    emitter = _progress_emitter.get()
+    if emitter is None:
+        return False
+    try:
+        emitter(event)
+        return True
+    except Exception:
+        return False

--- a/apps/server/agent/openai_agents/runner.py
+++ b/apps/server/agent/openai_agents/runner.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
+from agent.core.progress_channel import reset_progress_emitter, set_progress_emitter
 from agent.core.workflow_events import StreamEvent, StreamEventType
 from agent.graph.state import WritingState
 from agent.openai_agents.events import (
@@ -267,6 +270,30 @@ async def _inject_initial_steering(
         )
 
 
+async def _pump_sdk_events(result: Any, run_queue: "asyncio.Queue[tuple[str, Any]]") -> None:
+    """Forward SDK stream events onto the shared run queue, tagged by kind.
+
+    Runs as a background task so the consumer can interleave live in-tool
+    progress events (pushed onto the same queue via the progress channel) with
+    the SDK's own events. The SDK parks ``stream_events()`` while a tool's
+    callback runs, so without this pump those progress events could not be
+    surfaced until the tool returned.
+
+    Terminal protocol: on a stream exception, emits ``("error", exc)`` so the
+    consumer can re-raise it in the original control flow; ``("done", None)`` is
+    always emitted last so the consumer's drain loop can terminate.
+    """
+    try:
+        async for sdk_event in result.stream_events():
+            run_queue.put_nowait(("sdk", sdk_event))
+    except asyncio.CancelledError:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — forwarded to consumer for unified handling
+        run_queue.put_nowait(("error", exc))
+    finally:
+        run_queue.put_nowait(("done", None))
+
+
 async def run_openai_agents_streaming_agent(
     state: WritingState,
     agent_type: str,
@@ -303,6 +330,10 @@ async def run_openai_agents_streaming_agent(
         data={"model": DEEPSEEK_WRITING_MODEL, "agent_type": agent_type},
     )
 
+    # Shared queue interleaving SDK events (via _pump_sdk_events) with live
+    # in-tool progress events (via the progress channel emitter installed below).
+    run_queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+    pump_task: asyncio.Task[None] | None = None
     try:
         from agents import RunConfig, Runner, ToolExecutionConfig
         from agents.exceptions import MaxTurnsExceeded
@@ -310,27 +341,51 @@ async def run_openai_agents_streaming_agent(
         from .intra_run_trimmer import IntraRunToolOutputTrimmer
 
         sdk_agent = _build_agent(agent_type, system_prompt)
-        result = Runner.run_streamed(
-            sdk_agent,
-            input=api_messages,
-            max_turns=AGENT_TOOL_CALL_MAX_ITERATIONS,
-            # When DeepSeek emits multiple tool_calls in one turn, the SDK would run them
-            # concurrently (asyncio.create_task). Project tools share a single SQLAlchemy
-            # Session via ToolContext, which is NOT safe for concurrent use. Serialize tool
-            # execution to preserve the previous sequential contract and avoid Session races.
-            run_config=RunConfig(
-                tool_execution=ToolExecutionConfig(max_function_tool_concurrency=1),
-                # Preview stale intra-run retrieval outputs (query_files / hybrid_search)
-                # so a long multi-tool run doesn't re-send every bulky search dump on each
-                # subsequent model call. Keeps the freshest outputs full; control-flow tool
-                # outputs are never touched. See intra_run_trimmer for why the stock SDK
-                # ToolOutputTrimmer is a no-op for this project's history shape.
-                call_model_input_filter=IntraRunToolOutputTrimmer(),
-            ),
+        # Install the progress emitter only across run_streamed. The SDK creates
+        # its background task synchronously inside run_streamed, copying the
+        # current context (with the emitter) into it; that snapshot is
+        # independent of ours, so we reset immediately afterwards to keep this
+        # generator's context clean and avoid cross-yield contextvar tokens.
+        emitter_token = set_progress_emitter(
+            lambda event: run_queue.put_nowait(("progress", event))
         )
+        try:
+            result = Runner.run_streamed(
+                sdk_agent,
+                input=api_messages,
+                max_turns=AGENT_TOOL_CALL_MAX_ITERATIONS,
+                # When DeepSeek emits multiple tool_calls in one turn, the SDK would run them
+                # concurrently (asyncio.create_task). Project tools share a single SQLAlchemy
+                # Session via ToolContext, which is NOT safe for concurrent use. Serialize tool
+                # execution to preserve the previous sequential contract and avoid Session races.
+                run_config=RunConfig(
+                    tool_execution=ToolExecutionConfig(max_function_tool_concurrency=1),
+                    # Preview stale intra-run retrieval outputs (query_files / hybrid_search)
+                    # so a long multi-tool run doesn't re-send every bulky search dump on each
+                    # subsequent model call. Keeps the freshest outputs full; control-flow tool
+                    # outputs are never touched. See intra_run_trimmer for why the stock SDK
+                    # ToolOutputTrimmer is a no-op for this project's history shape.
+                    call_model_input_filter=IntraRunToolOutputTrimmer(),
+                ),
+            )
+        finally:
+            reset_progress_emitter(emitter_token)
+
+        pump_task = asyncio.create_task(_pump_sdk_events(result, run_queue))
 
         try:
-            async for sdk_event in result.stream_events():
+            while True:
+                kind, payload = await run_queue.get()
+                if kind == "progress":
+                    # Pre-built workflow/SSE event emitted from inside a tool call
+                    # (e.g. parallel_execute sub-task progress). Forward as-is.
+                    yield payload
+                    continue
+                if kind == "done":
+                    break
+                if kind == "error":
+                    raise payload
+                sdk_event = payload
                 event_type = getattr(sdk_event, "type", "")
 
                 if event_type == "raw_response_event":
@@ -525,6 +580,12 @@ async def run_openai_agents_streaming_agent(
             data={"error": str(exc), "error_type": type(exc).__name__},
         )
     finally:
+        # Stop the SDK pump if it is still running (e.g. the consumer aborted
+        # early before the stream drained), so it cannot outlive this run.
+        if pump_task is not None and not pump_task.done():
+            pump_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await pump_task
         _append_assistant_turn_to_state_messages(
             state,
             api_messages,

--- a/apps/server/agent/prompts/base.py
+++ b/apps/server/agent/prompts/base.py
@@ -211,6 +211,25 @@ def get_tool_usage_guide(folder_ids: dict[str, str], primary_content_type: str) 
 - hybrid_search: 混合检索（向量 + 关键词融合）
 - update_project: 更新项目状态信息（用于记录项目背景和写作指导）
 - update_project(tasks=[...]): 管理任务计划板（复杂任务时必须先调用此参数规划）
+- parallel_execute: 一次并行执行多个**相互独立**的任务（批量提速）
+
+### parallel_execute 使用场景 [批量提速]
+
+当你有**多个彼此独立、互不依赖**的操作需要执行时，用 `parallel_execute` 一次性并发完成，比逐个调用更快。
+
+**适用场景**：
+- 批量删除/查询多个文件（如清理多个草稿、并行检索多份资料）
+- 同时对多个**不同**文件做互不影响的编辑
+
+**调用格式**：`parallel_execute(tasks=[{{"type": ..., "description": ..., "params": {{...}}}}, ...])`
+- 支持的 type：`edit_file`、`delete_file`、`query_files`、`hybrid_search`、`write_chapter`
+- 每个 task 的 params 与对应单体工具一致（如 edit_file 用 `id`+`edits`）
+- 最多 5 个任务
+
+**严格约束**：
+- 任务之间**必须独立**——一个任务的结果不能作为另一个任务的输入；有先后依赖时**不要**用它，改为逐步调用
+- 需要 `<file>` 流式写入正文的**新章节创作**仍用单体 `create_file`（parallel 的 write_chapter 不走流式，仅适合一次性短内容）
+- 若有空文件尚未写入内容，parallel_execute 会被拒绝——先完成该文件
 
 ### 文件 ID 使用规则 [非常重要]
 - 永远不要编造/猜测 id

--- a/apps/server/agent/service.py
+++ b/apps/server/agent/service.py
@@ -459,6 +459,7 @@ class AgentService:
         # Initialize tracking variables before try block for exception safety
         all_tool_calls: list[dict[str, Any]] = []
         tool_call_index_by_id: dict[str, int] = {}
+        consumed_steering: list[str] = []
         assistant_response = ""
         reasoning_content = ""
         assistant_stop_reason: str | None = None
@@ -704,7 +705,14 @@ class AgentService:
             async def get_steering_messages():
                 """Get pending steering messages for agent loop."""
                 messages = await steering_queue.get_pending()
-                return [{"id": m.id, "content": m.content} for m in messages]
+                payload = [{"id": m.id, "content": m.content} for m in messages]
+                # Record what the run actually consumed so it can be persisted to
+                # chat history (otherwise node-boundary steering is lost on the
+                # next request).
+                consumed_steering.extend(
+                    str(item["content"]) for item in payload if item.get("content")
+                )
+                return payload
 
             try:
                 # Process through workflow stream
@@ -829,6 +837,7 @@ class AgentService:
                     assistant_stop_reason=assistant_stop_reason,
                     assistant_usage=assistant_usage,
                     assistant_status_cards=assistant_status_cards or None,
+                    steering_messages=consumed_steering or None,
                 )
                 if pending_done_payload is not None:
                     refs_candidate = pending_done_payload.get("refs")

--- a/apps/server/agent/tools/parallel_executor.py
+++ b/apps/server/agent/tools/parallel_executor.py
@@ -122,6 +122,18 @@ def _make_error(error: str) -> dict[str, Any]:
     }
 
 
+def _result_preview(result: Any, max_length: int = 100) -> str | None:
+    """Build a short preview of a task result for live progress events."""
+    if result is None:
+        return None
+    try:
+        text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = str(result)
+    text = text.strip()
+    return text[:max_length] if text else None
+
+
 async def handle_write_chapter(params: dict[str, Any]) -> dict[str, Any]:
     """Handle write_chapter task type - creates a draft file."""
     from agent.tools.mcp_tools import ToolContext, create_file
@@ -271,6 +283,13 @@ async def execute_parallel(
     Returns:
         ParallelExecutionResult as MCP-formatted dict
     """
+    from agent.core.events import (
+        parallel_end_event,
+        parallel_start_event,
+        parallel_task_end_event,
+        parallel_task_start_event,
+    )
+    from agent.core.progress_channel import emit_progress
     from agent.tools.mcp_tools import ToolContext
 
     # Check if there's a pending empty file - parallel execution not allowed
@@ -305,6 +324,15 @@ async def execute_parallel(
         for i, t in enumerate(limited_tasks)
     ]
 
+    # Announce parallel execution start so the UI can render live progress.
+    emit_progress(
+        parallel_start_event(
+            execution_id=execution_id,
+            task_count=len(subagent_tasks),
+            task_descriptions=[t.description for t in subagent_tasks],
+        )
+    )
+
     # Map task types to handlers
     task_handlers: dict[str, Callable] = {
         "write_chapter": handle_write_chapter,
@@ -320,6 +348,14 @@ async def execute_parallel(
         async with semaphore:
             task.status = "running"
             task.started_at = datetime.now()
+            emit_progress(
+                parallel_task_start_event(
+                    execution_id=execution_id,
+                    task_id=task.id,
+                    task_type=task.task_type,
+                    description=task.description,
+                )
+            )
 
             try:
                 handler = task_handlers.get(task.task_type)
@@ -371,6 +407,15 @@ async def execute_parallel(
                 logger.error(f"parallel_execute task failed: {e}", exc_info=True)
             finally:
                 task.completed_at = datetime.now()
+                emit_progress(
+                    parallel_task_end_event(
+                        execution_id=execution_id,
+                        task_id=task.id,
+                        status=task.status,
+                        result_preview=_result_preview(task.result),
+                        error=task.error,
+                    )
+                )
 
             return task
 
@@ -402,9 +447,24 @@ async def execute_parallel(
         ],
     }
 
+    # Announce completion with the aggregate outcome for the UI summary line.
+    emit_progress(
+        parallel_end_event(
+            execution_id=execution_id,
+            total_tasks=result_data["total_tasks"],
+            completed=result_data["completed"],
+            failed=result_data["failed"],
+            duration_ms=duration_ms,
+        )
+    )
+
     logger.info(
         f"parallel_execute completed: {result_data['completed']}/{result_data['total_tasks']} "
         f"tasks in {duration_ms}ms"
     )
 
+    # Always return a "success" envelope so the per-task breakdown (data.tasks[])
+    # survives the stream adapter, which drops `data` for non-success tool
+    # results. Partial/total failure is conveyed by data.any_failed / data.failed
+    # and per-task status+error, which both the LLM and the UI card read.
     return _make_result({"status": "success", "data": result_data})

--- a/apps/server/tests/test_agent/test_parallel_steering_rework.py
+++ b/apps/server/tests/test_agent/test_parallel_steering_rework.py
@@ -1,0 +1,433 @@
+"""Tests for the parallel-execution + steering rework.
+
+Covers the pieces the original audit found unwired or unverified end-to-end:
+- the in-band progress channel (agent.core.progress_channel)
+- parallel_execute emitting live parallel_* progress events
+- the runner's SDK/progress merge pump (_pump_sdk_events) and its contextvar
+  propagation through run_openai_agents_streaming_agent
+- steering messages being persisted to chat history (node-boundary durability)
+"""
+
+import asyncio
+import json
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from agent.core import progress_channel
+from agent.core.progress_channel import (
+    emit_progress,
+    reset_progress_emitter,
+    set_progress_emitter,
+)
+from agent.tools.parallel_executor import execute_parallel
+
+
+# ---------------------------------------------------------------------------
+# progress_channel
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestProgressChannel:
+    def test_emit_without_channel_is_noop(self):
+        # No emitter installed -> returns False, never raises.
+        assert emit_progress({"any": "event"}) is False
+
+    def test_emit_with_channel_delivers_then_resets(self):
+        captured: list = []
+        token = set_progress_emitter(captured.append)
+        try:
+            assert emit_progress("e1") is True
+            assert emit_progress("e2") is True
+        finally:
+            reset_progress_emitter(token)
+        assert captured == ["e1", "e2"]
+        # After reset the channel is gone again.
+        assert emit_progress("e3") is False
+        assert captured == ["e1", "e2"]
+
+    def test_emit_swallows_emitter_errors(self):
+        def boom(_event):
+            raise RuntimeError("emitter failed")
+
+        token = set_progress_emitter(boom)
+        try:
+            # Must not propagate the emitter's error to the caller.
+            assert emit_progress("x") is False
+        finally:
+            reset_progress_emitter(token)
+
+
+# ---------------------------------------------------------------------------
+# parallel_execute progress emission
+# ---------------------------------------------------------------------------
+def _event_value(event) -> str:
+    """Normalize a workflow/SSE event's type to its string value."""
+    event_type = getattr(event, "type", "")
+    return getattr(event_type, "value", str(event_type))
+
+
+@pytest.mark.unit
+class TestParallelProgressEmission:
+    async def test_emits_full_progress_sequence(self):
+        from agent.tools.mcp_tools import ToolContext
+
+        captured: list = []
+        token = set_progress_emitter(captured.append)
+        ToolContext.set_context(None, "user1", "proj-1", "sess-1")
+        try:
+            with patch("agent.tools.parallel_executor.handle_query_files") as mock_query:
+                mock_query.return_value = {
+                    "content": [{"type": "text", "text": '{"count": 1}'}]
+                }
+                await execute_parallel(
+                    [
+                        {"type": "query_files", "description": "Q1", "params": {}},
+                        {"type": "query_files", "description": "Q2", "params": {}},
+                    ]
+                )
+        finally:
+            reset_progress_emitter(token)
+            ToolContext.clear_context()
+
+        values = [_event_value(e) for e in captured]
+        # One start, one end per task, one overall end.
+        assert values[0] == "parallel_start"
+        assert values[-1] == "parallel_end"
+        assert values.count("parallel_task_start") == 2
+        assert values.count("parallel_task_end") == 2
+
+        start = captured[0]
+        assert start.data["task_count"] == 2
+        assert start.data["task_descriptions"] == ["Q1", "Q2"]
+
+        end = captured[-1]
+        assert end.data["total_tasks"] == 2
+        assert end.data["completed"] == 2
+        assert end.data["failed"] == 0
+
+    async def test_partial_failure_reported_in_progress_and_envelope(self):
+        from agent.tools.mcp_tools import ToolContext
+
+        captured: list = []
+        token = set_progress_emitter(captured.append)
+        ToolContext.set_context(None, "user1", "proj-1", "sess-1")
+        try:
+            # One success, one error payload.
+            with patch("agent.tools.parallel_executor.handle_query_files") as mock_query:
+                mock_query.side_effect = [
+                    {"content": [{"type": "text", "text": '{"ok": true}'}]},
+                    {"content": [{"type": "text", "text": '{"status":"error","error":"boom"}'}]},
+                ]
+                result = await execute_parallel(
+                    [
+                        {"type": "query_files", "description": "good", "params": {}},
+                        {"type": "query_files", "description": "bad", "params": {}},
+                    ]
+                )
+        finally:
+            reset_progress_emitter(token)
+            ToolContext.clear_context()
+
+        end = captured[-1]
+        assert _event_value(end) == "parallel_end"
+        assert end.data["completed"] == 1
+        assert end.data["failed"] == 1
+
+        # Envelope stays "success" so the per-task breakdown survives the stream
+        # adapter, but the failure is visible in the data fields.
+        parsed = json.loads(result["content"][0]["text"])
+        assert parsed["status"] == "success"
+        assert parsed["data"]["any_failed"] is True
+        assert parsed["data"]["failed"] == 1
+
+        # A failed task_end carries its error message.
+        task_ends = [e for e in captured if _event_value(e) == "parallel_task_end"]
+        failed = [e for e in task_ends if e.data["status"] == "failed"]
+        assert len(failed) == 1
+        assert "boom" in (failed[0].data.get("error") or "")
+
+    async def test_no_emitter_does_not_break_execution(self):
+        from agent.tools.mcp_tools import ToolContext
+
+        ToolContext.set_context(None, "user1", "proj-1", "sess-1")
+        try:
+            with patch("agent.tools.parallel_executor.handle_query_files") as mock_query:
+                mock_query.return_value = {
+                    "content": [{"type": "text", "text": '{"count": 0}'}]
+                }
+                result = await execute_parallel(
+                    [{"type": "query_files", "description": "Q", "params": {}}]
+                )
+            parsed = json.loads(result["content"][0]["text"])
+            assert parsed["status"] == "success"
+            assert parsed["data"]["total_tasks"] == 1
+        finally:
+            ToolContext.clear_context()
+
+
+# ---------------------------------------------------------------------------
+# runner pump
+# ---------------------------------------------------------------------------
+def _drain(queue: asyncio.Queue) -> list:
+    items = []
+    while not queue.empty():
+        items.append(queue.get_nowait())
+    return items
+
+
+class _FakeStream:
+    def __init__(self, events, *, raise_after=None):
+        self._events = events
+        self._raise_after = raise_after
+
+    async def stream_events(self):
+        for event in self._events:
+            await asyncio.sleep(0)
+            yield event
+        if self._raise_after is not None:
+            raise self._raise_after
+
+
+@pytest.mark.unit
+class TestRunnerPump:
+    async def test_forwards_events_then_done(self):
+        from agent.openai_agents.runner import _pump_sdk_events
+
+        queue: asyncio.Queue = asyncio.Queue()
+        await _pump_sdk_events(_FakeStream(["a", "b"]), queue)
+        assert _drain(queue) == [("sdk", "a"), ("sdk", "b"), ("done", None)]
+
+    async def test_forwards_stream_exception_then_done(self):
+        from agent.openai_agents.runner import _pump_sdk_events
+
+        boom = RuntimeError("stream failed")
+        queue: asyncio.Queue = asyncio.Queue()
+        await _pump_sdk_events(_FakeStream(["a"], raise_after=boom), queue)
+        items = _drain(queue)
+        assert items[0] == ("sdk", "a")
+        assert items[1][0] == "error" and items[1][1] is boom
+        assert items[-1] == ("done", None)
+
+
+# ---------------------------------------------------------------------------
+# runner integration: SDK + live progress merge + steering injection
+# ---------------------------------------------------------------------------
+class _RawDelta:
+    """Mimics a raw_response_event payload carrying a text delta."""
+
+    def __init__(self, delta: str):
+        self.type = "response.output_text.delta"
+        self.delta = delta
+
+
+class _RawResponseEvent:
+    def __init__(self, delta: str):
+        self.type = "raw_response_event"
+        self.data = _RawDelta(delta)
+
+
+class _FakeRunResult:
+    def __init__(self, events):
+        self._events = events
+        self.raw_responses = []
+
+    async def stream_events(self):
+        for event in self._events:
+            await asyncio.sleep(0)
+            yield event
+
+    def cancel(self, mode=None):  # pragma: no cover - not exercised here
+        pass
+
+
+def _install_fake_agents(monkeypatch, *, emit_events):
+    """Install a fake openai-agents SDK that emits given progress events mid-run."""
+    fake_agents = types.ModuleType("agents")
+
+    class _Runner:
+        @staticmethod
+        def run_streamed(agent, input, max_turns, run_config):  # noqa: A002 - mirror SDK kwarg
+            # Created while the runner has the progress emitter installed, so the
+            # task's context copy can deliver progress events — exactly the
+            # contextvar propagation the production runner relies on.
+            async def _emit():
+                await asyncio.sleep(0)
+                for event in emit_events:
+                    emit_progress(event)
+
+            asyncio.create_task(_emit())
+            return _FakeRunResult([_RawResponseEvent("hello "), _RawResponseEvent("world")])
+
+    def _run_config(**kwargs):
+        return {"run_config": kwargs}
+
+    def _tool_execution_config(**kwargs):
+        return {"tool_execution": kwargs}
+
+    fake_agents.Runner = _Runner
+    fake_agents.RunConfig = _run_config
+    fake_agents.ToolExecutionConfig = _tool_execution_config
+
+    fake_exceptions = types.ModuleType("agents.exceptions")
+
+    class _MaxTurnsExceeded(Exception):
+        pass
+
+    fake_exceptions.MaxTurnsExceeded = _MaxTurnsExceeded
+
+    monkeypatch.setitem(sys.modules, "agents", fake_agents)
+    monkeypatch.setitem(sys.modules, "agents.exceptions", fake_exceptions)
+
+
+@pytest.mark.unit
+class TestRunnerIntegration:
+    async def test_progress_events_interleave_with_sdk_text(self, monkeypatch):
+        from agent.core.events import (
+            parallel_end_event,
+            parallel_start_event,
+        )
+        from agent.openai_agents.runner import run_openai_agents_streaming_agent
+
+        _install_fake_agents(
+            monkeypatch,
+            emit_events=[
+                parallel_start_event(execution_id="x", task_count=1, task_descriptions=["d"]),
+                parallel_end_event(
+                    execution_id="x", total_tasks=1, completed=1, failed=0, duration_ms=5
+                ),
+            ],
+        )
+
+        with patch("agent.openai_agents.runner._build_agent", return_value=object()):
+            state = {"messages": [], "user_message": "hi"}
+            collected = [
+                event
+                async for event in run_openai_agents_streaming_agent(state, "writer", "sys")
+            ]
+
+        values = [_event_value(e) for e in collected]
+        # Normal SDK lifecycle still intact.
+        assert "message_start" in values
+        assert "message_end" in values
+        assert "text" in values
+        # Live in-tool progress surfaced through the merge.
+        assert "parallel_start" in values
+        assert "parallel_end" in values
+        # Assistant text accumulated from the two deltas.
+        text = "".join(
+            e.data.get("text", "") for e in collected if _event_value(e) == "text"
+        )
+        assert text == "hello world"
+
+    async def test_steering_injected_before_message_start(self, monkeypatch):
+        from agent.openai_agents.runner import run_openai_agents_streaming_agent
+
+        _install_fake_agents(monkeypatch, emit_events=[])
+
+        async def get_steering_messages():
+            return [{"id": "s1", "content": "把主角改名为林川"}]
+
+        with patch("agent.openai_agents.runner._build_agent", return_value=object()):
+            state = {"messages": [], "user_message": "继续写"}
+            collected = [
+                event
+                async for event in run_openai_agents_streaming_agent(
+                    state, "writer", "sys", get_steering_messages=get_steering_messages
+                )
+            ]
+
+        values = [_event_value(e) for e in collected]
+        assert "steering_received" in values
+        # Steering is injected before the model run starts.
+        assert values.index("steering_received") < values.index("message_start")
+
+
+# ---------------------------------------------------------------------------
+# steering persistence
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSteeringPersistence:
+    def test_steering_messages_saved_as_user_turns(self, db_session):
+        from agent.core.message_manager import MessageManager
+        from models import ChatMessage, Project, User
+        from sqlmodel import select
+
+        user = User(
+            email="steer-persist@example.com",
+            username="steer_persist",
+            hashed_password="hashed_password",
+            email_verified=True,
+            is_active=True,
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        project = Project(name="Steer Project", owner_id=user.id, project_type="novel")
+        db_session.add(project)
+        db_session.commit()
+        db_session.refresh(project)
+
+        manager = MessageManager(project_id=project.id, user_id=user.id)
+        manager._save_messages_with_session(
+            db_session,
+            None,
+            "原始用户消息",
+            "助手最终回复",
+            None,
+            None,
+            steering_messages=["把主角改名为林川", "   ", "再加一条线索"],
+        )
+
+        rows = db_session.exec(select(ChatMessage)).all()
+        contents = [r.content for r in rows]
+        roles = [r.role for r in rows]
+
+        # user + 2 non-empty steering + assistant; the whitespace-only one is dropped.
+        assert len(rows) == 4
+        assert roles.count("user") == 3
+        assert roles.count("assistant") == 1
+        assert "原始用户消息" in contents
+        assert "把主角改名为林川" in contents
+        assert "再加一条线索" in contents
+        assert "助手最终回复" in contents
+        assert "   " not in contents
+
+        chat_session_id = rows[0].session_id
+        from models import ChatSession
+
+        chat_session = db_session.get(ChatSession, chat_session_id)
+        # 2 base messages + 2 persisted steering turns.
+        assert chat_session.message_count == 4
+
+    def test_no_steering_messages_keeps_two_message_turns(self, db_session):
+        from agent.core.message_manager import MessageManager
+        from models import ChatMessage, Project, User
+        from sqlmodel import select
+
+        user = User(
+            email="steer-none@example.com",
+            username="steer_none",
+            hashed_password="hashed_password",
+            email_verified=True,
+            is_active=True,
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        project = Project(name="No Steer Project", owner_id=user.id, project_type="novel")
+        db_session.add(project)
+        db_session.commit()
+        db_session.refresh(project)
+
+        manager = MessageManager(project_id=project.id, user_id=user.id)
+        manager._save_messages_with_session(
+            db_session, None, "你好", "你好，有什么可以帮你", None, None
+        )
+
+        rows = db_session.exec(select(ChatMessage)).all()
+        assert len(rows) == 2
+        assert {r.role for r in rows} == {"user", "assistant"}

--- a/apps/web/public/locales/en/chat.json
+++ b/apps/web/public/locales/en/chat.json
@@ -28,6 +28,11 @@
   "input": {
     "placeholder": "Describe the character, scene, or plot you want to create...",
     "placeholderWhileProcessing": "AI is generating — you can type now and send when it finishes…",
+    "steerPlaceholder": "Add a follow-up instruction — applied at the next step…",
+    "steerButton": "Add instruction",
+    "steerHint": "AI is generating: what you send becomes a follow-up instruction, applied at the next step",
+    "steerSent": "Added — it will apply at the next step",
+    "steerFailed": "Failed to add, please retry",
     "mode": {
       "label": "Mode",
       "fast": "Fast",
@@ -133,6 +138,8 @@
     "stopReason": "Reason: {{reason}}",
     "handoffMessage": "Handing off to {{agent}}: {{reason}}",
     "parallelStart": "Starting {{count}} parallel tasks",
+    "parallelTaskCompleted": "✓ {{description}}",
+    "parallelTaskFailed": "✗ {{description}}: {{error}}",
     "parallelEnd": "Parallel execution complete: {{completed}}/{{total}} done, {{failed}} failed",
     "steeringReceived": "Supplementary instruction received: {{preview}}"
   },
@@ -143,6 +150,8 @@
     "delete_file": "Delete File",
     "query_files": "Query Files",
     "update_project": "Update Project Status",
+    "parallel_execute": "Parallel Execution",
+    "parallel_summary": "Ran {{total}} tasks in parallel: {{completed}} succeeded, {{failed}} failed",
     "processing": "Processing",
     "processing_ellipsis": "Processing...",
     "created": "Created {{type}}",

--- a/apps/web/public/locales/zh/chat.json
+++ b/apps/web/public/locales/zh/chat.json
@@ -28,6 +28,11 @@
   "input": {
     "placeholder": "描述你想创作的角色、场景或剧情...",
     "placeholderWhileProcessing": "AI 正在生成，你可以先输入，结束后再发送…",
+    "steerPlaceholder": "追加补充指令，将在下一步生效…",
+    "steerButton": "追加指令",
+    "steerHint": "AI 生成中：发送的内容会作为补充指令，在下一步生效",
+    "steerSent": "已追加，将在下一步生效",
+    "steerFailed": "追加失败，请重试",
     "mode": {
       "label": "生成模式",
       "fast": "快速",
@@ -133,6 +138,8 @@
     "stopReason": "原因：{{reason}}",
     "handoffMessage": "交接给 {{agent}}：{{reason}}",
     "parallelStart": "开始并行执行 {{count}} 个任务",
+    "parallelTaskCompleted": "✓ {{description}}",
+    "parallelTaskFailed": "✗ {{description}}：{{error}}",
     "parallelEnd": "并行执行结束：{{completed}}/{{total}} 完成，{{failed}} 失败",
     "steeringReceived": "已接收补充指令：{{preview}}"
   },
@@ -143,6 +150,8 @@
     "delete_file": "删除文件",
     "query_files": "查询文件",
     "update_project": "更新项目状态",
+    "parallel_execute": "并行执行",
+    "parallel_summary": "并行执行 {{total}} 个任务：{{completed}} 成功，{{failed}} 失败",
     "processing": "处理中",
     "processing_ellipsis": "处理中...",
     "created": "已创建{{type}}",

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -829,6 +829,8 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
     conflicts,
     error,
     errorCode,
+    sessionId,
+    sendSteeringMessage,
   } = useAgentStream(currentProjectId!, {
     // Lifecycle callbacks
     onStart: () => {
@@ -1166,6 +1168,22 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
     // Start streaming
     startStream(request);
   }, [isStreaming, selectedItem?.id, selectedItem?.type, selectedItem?.title, attachedFileIds, attachedLibraryMaterials, quotes, generationMode, startStream, clearDraft, setAiSuggestions, currentProjectId]);
+
+  /**
+   * Send a steering (follow-up) instruction while the agent is generating.
+   * The backend queues it and the agent picks it up at its next step, so the
+   * toast sets that expectation ("applies at the next step").
+   */
+  const handleSteer = useCallback(async (message: string) => {
+    if (!message.trim() || !isStreaming) return;
+    try {
+      await sendSteeringMessage(message);
+      toast.success(t("chat:input.steerSent"));
+    } catch (err) {
+      console.error("Failed to send steering message", err);
+      toast.error(t("chat:input.steerFailed"));
+    }
+  }, [isStreaming, sendSteeringMessage, t]);
 
   const handleIterationAssistAction = useCallback(
     (action: 'continue' | 'split' | 'manual') => {
@@ -1720,6 +1738,10 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
             disabled={isLoadingHistory}
             sendDisabled={isStreaming || isThinking || isLoadingHistory}
             onCancel={isStreaming ? handleCancel : undefined}
+            // Steering: while streaming with an active session, the user can send
+            // a follow-up instruction that the agent picks up at its next step.
+            onSteer={handleSteer}
+            canSteer={isStreaming && !!sessionId}
             placeholder={
               isStreaming || isThinking
                 ? t("chat:input.placeholderWhileProcessing")

--- a/apps/web/src/components/MessageInput.tsx
+++ b/apps/web/src/components/MessageInput.tsx
@@ -176,6 +176,14 @@ interface MessageInputProps {
   sendDisabled?: boolean;
   /** Callback to cancel an ongoing operation (shows cancel button when disabled) */
   onCancel?: () => void;
+  /**
+   * Callback to send a steering (follow-up) message while the agent is
+   * streaming. When provided together with `canSteer`, typing during
+   * generation and sending dispatches a steering message instead of a new turn.
+   */
+  onSteer?: (message: string) => void | Promise<void>;
+  /** Whether steering is currently available (agent streaming + active session). */
+  canSteer?: boolean;
   /** Custom placeholder text (defaults to i18n "chat:input.placeholder") */
   placeholder?: string;
   /** AI-generated context-aware suggestions to display */
@@ -268,6 +276,8 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   disabled = false,
   sendDisabled,
   onCancel,
+  onSteer,
+  canSteer = false,
   placeholder,
   aiSuggestions = [],
   suggestionDisplayState = aiSuggestions.length > 0 ? "ready" : "fallback",
@@ -285,6 +295,10 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const textareaMinHeightPx = isMobile ? 44 : TEXTAREA_MIN_HEIGHT_PX;
   const effectiveSendDisabled = sendDisabled ?? disabled;
   const inputDisabled = disabled;
+  // Steering is offered while the agent is generating: the textarea stays
+  // editable and submitting dispatches a follow-up instruction instead of a
+  // brand-new turn.
+  const steerActive = canSteer && !!onSteer && !inputDisabled;
 
   const allStaticSuggestions = useMemo(() => {
     const raw = t("chat:input.staticSuggestions", { returnObjects: true }) as unknown;
@@ -529,10 +543,25 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         return;
       }
     }
-    // Enter 发送
+    // Enter 发送（生成中且可追加时，发送补充指令）
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      handleSubmit();
+      if (steerActive) {
+        handleSteer();
+      } else {
+        handleSubmit();
+      }
+    }
+  };
+
+  const handleSteer = () => {
+    const trimmed = input.trim();
+    if (!trimmed || !onSteer) return;
+    void onSteer(trimmed);
+    setInput("");
+    setSkillTriggers([]);
+    if (textareaRef.current && layout === "auto") {
+      textareaRef.current.style.height = "auto";
     }
   };
 
@@ -575,7 +604,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     setTimeout(adjustHeight, 0);
   };
 
-  const displayPlaceholder = placeholder ?? t("chat:input.placeholder");
+  const displayPlaceholder = steerActive
+    ? t("chat:input.steerPlaceholder")
+    : (placeholder ?? t("chat:input.placeholder"));
   const generationModeLabel =
     generationMode === "fast" ? t("chat:input.mode.fast") : t("chat:input.mode.quality");
   const generationModeHint =
@@ -804,6 +835,16 @@ export const MessageInput: React.FC<MessageInputProps> = ({
         accessoryRows
       )}
 
+      {/* Steering hint: shown while the agent is generating and steering is available */}
+      {steerActive ? (
+        <div
+          className="text-xs text-[hsl(var(--text-secondary))] px-1"
+          data-testid="steer-hint"
+        >
+          {t("chat:input.steerHint")}
+        </div>
+      ) : null}
+
       {/* Input row */}
       <div
         className={
@@ -866,7 +907,18 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           data-testid="chat-input"
         />
 
-        {onCancel && effectiveSendDisabled ? (
+        {steerActive && input.trim() ? (
+          <button
+            onClick={handleSteer}
+            disabled={!input.trim()}
+            className={`shrink-0 flex items-center justify-center bg-[hsl(var(--accent-primary))] hover:bg-[hsl(var(--accent-dark))] disabled:bg-[hsl(var(--bg-tertiary))] disabled:cursor-not-allowed text-white rounded-lg transition-colors focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_hsl(var(--bg-primary)),_0_0_0_4px_hsl(var(--accent-primary))] ${isMobile ? 'w-11 h-11' : 'w-9 h-9'}`}
+            title={t("chat:input.steerButton")}
+            aria-label={t("chat:input.steerButton")}
+            data-testid="steer-button"
+          >
+            <Send size={16} />
+          </button>
+        ) : onCancel && effectiveSendDisabled ? (
           <button
             onClick={handleCancel}
             className={`shrink-0 flex items-center justify-center bg-[hsl(var(--error))] hover:bg-[hsl(var(--error))] text-white rounded-lg transition-colors focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_hsl(var(--bg-primary)),_0_0_0_4px_hsl(var(--error))] ${isMobile ? 'w-11 h-11' : 'w-9 h-9'}`}

--- a/apps/web/src/components/ToolResultCard.tsx
+++ b/apps/web/src/components/ToolResultCard.tsx
@@ -42,6 +42,7 @@ import {
   BookOpen,
   ScrollText,
   Settings,
+  Layers,
 } from 'lucide-react';
 import type { Conflict, AgentResponse } from '../types';
 
@@ -217,6 +218,11 @@ const getToolDisplayInfo = (toolName: string, t: (key: string) => string): { ico
       return {
         icon: <Settings className="w-4 h-4 text-[hsl(var(--warning))]" />,
         label: t('chat:tool.update_project')
+      };
+    case 'parallel_execute':
+      return {
+        icon: <Layers className="w-4 h-4 text-[hsl(var(--accent-primary))]" />,
+        label: t('chat:tool.parallel_execute')
       };
     default:
       return { 
@@ -810,6 +816,78 @@ const ToolResultCardComponent: React.FC<ToolResultCardProps> = ({
       );
     }
     
+    // parallel_execute success - show per-subtask status so partial failures
+    // are visible (the aggregate envelope stays "success" to preserve data).
+    if (toolName === 'parallel_execute' && data) {
+      const tasks = Array.isArray(data.tasks)
+        ? (data.tasks as Array<Record<string, unknown>>)
+        : [];
+      const total = (data.total_tasks as number) ?? tasks.length;
+      const completed =
+        (data.completed as number) ??
+        tasks.filter((task) => task.status === 'completed').length;
+      const failed =
+        (data.failed as number) ??
+        tasks.filter((task) => task.status === 'failed').length;
+      const anyFailed = failed > 0;
+      const accentClass = anyFailed
+        ? 'text-[hsl(var(--warning))]'
+        : 'text-[hsl(var(--success-light))]';
+
+      return (
+        <div
+          className={`bg-[hsl(var(--result-bg))] border rounded-lg px-3 py-2 ${
+            anyFailed
+              ? 'border-[hsl(var(--warning))]'
+              : 'border-[hsl(var(--result-border))]'
+          }`}
+        >
+          <div className="flex items-center gap-2">
+            <Layers className={`w-4 h-4 ${accentClass}`} />
+            <span className={`text-sm ${accentClass}`}>
+              {t('chat:tool.parallel_summary', { total, completed, failed })}
+            </span>
+          </div>
+          {tasks.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {tasks.map((task, index) => {
+                const isFailed = task.status === 'failed';
+                const desc =
+                  (task.description as string) ||
+                  (task.type as string) ||
+                  `#${index + 1}`;
+                return (
+                  <div
+                    key={(task.id as string) || index}
+                    className="flex items-start gap-2 text-xs"
+                  >
+                    {isFailed ? (
+                      <XCircle className="w-3.5 h-3.5 mt-0.5 shrink-0 text-[hsl(var(--error))]" />
+                    ) : (
+                      <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 shrink-0 text-[hsl(var(--success-light))]" />
+                    )}
+                    <div className="min-w-0">
+                      <span className="text-[hsl(var(--text-secondary))]">
+                        [{task.type as string}]
+                      </span>{' '}
+                      <span className="text-[hsl(var(--text-primary))] break-words">
+                        {desc}
+                      </span>
+                      {isFailed && task.error ? (
+                        <div className="text-[hsl(var(--error))] break-words">
+                          {task.error as string}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      );
+    }
+
     // Default fallback - show minimal success message without technical details
     const { label } = getToolDisplayInfo(toolName, t);
     return (

--- a/apps/web/src/components/__tests__/MessageInput.test.tsx
+++ b/apps/web/src/components/__tests__/MessageInput.test.tsx
@@ -468,4 +468,104 @@ describe('MessageInput', () => {
     await user.click(screen.getByRole('button', { name: /chat:input.mode.label/i }))
     expect(onGenerationModeChange).toHaveBeenCalledWith('fast')
   })
+
+  describe('steering (追加消息)', () => {
+    const steerProps = {
+      sendDisabled: true,
+      onCancel: vi.fn(),
+      onSteer: vi.fn(),
+      canSteer: true,
+    }
+
+    it('shows the steering placeholder and hint while generating', () => {
+      render(<MessageInput {...defaultProps} {...steerProps} />)
+      expect(
+        screen.getByPlaceholderText('chat:input.steerPlaceholder')
+      ).toBeInTheDocument()
+      expect(screen.getByTestId('steer-hint')).toBeInTheDocument()
+    })
+
+    it('keeps the textarea editable while generating', () => {
+      render(<MessageInput {...defaultProps} {...steerProps} />)
+      expect(
+        screen.getByPlaceholderText('chat:input.steerPlaceholder')
+      ).not.toBeDisabled()
+    })
+
+    it('shows cancel when empty, and a steer button once text is typed', async () => {
+      const user = userEvent.setup({ delay: null })
+      render(<MessageInput {...defaultProps} {...steerProps} />)
+
+      // Empty input while streaming -> cancel button, no steer button.
+      expect(screen.queryByTestId('steer-button')).not.toBeInTheDocument()
+
+      await user.type(
+        screen.getByPlaceholderText('chat:input.steerPlaceholder'),
+        '把主角改名为林川'
+      )
+      expect(screen.getByTestId('steer-button')).toBeInTheDocument()
+    })
+
+    it('dispatches onSteer (not onSend) when sending during generation', async () => {
+      const user = userEvent.setup({ delay: null })
+      const onSend = vi.fn()
+      const onSteer = vi.fn()
+      render(
+        <MessageInput
+          {...defaultProps}
+          onSend={onSend}
+          sendDisabled={true}
+          onCancel={vi.fn()}
+          onSteer={onSteer}
+          canSteer={true}
+        />
+      )
+
+      const textarea = screen.getByPlaceholderText('chat:input.steerPlaceholder')
+      await user.type(textarea, '补充指令')
+      await user.click(screen.getByTestId('steer-button'))
+
+      expect(onSteer).toHaveBeenCalledWith('补充指令')
+      expect(onSend).not.toHaveBeenCalled()
+      await waitFor(() => expect(textarea).toHaveValue(''))
+    })
+
+    it('steers on Enter while generating', async () => {
+      const user = userEvent.setup({ delay: null })
+      const onSend = vi.fn()
+      const onSteer = vi.fn()
+      render(
+        <MessageInput
+          {...defaultProps}
+          onSend={onSend}
+          sendDisabled={true}
+          onCancel={vi.fn()}
+          onSteer={onSteer}
+          canSteer={true}
+        />
+      )
+
+      const textarea = screen.getByPlaceholderText('chat:input.steerPlaceholder')
+      await user.type(textarea, '下一步加一段悬念{Enter}')
+
+      expect(onSteer).toHaveBeenCalledWith('下一步加一段悬念')
+      expect(onSend).not.toHaveBeenCalled()
+    })
+
+    it('does not offer steering when canSteer is false', () => {
+      render(
+        <MessageInput
+          {...defaultProps}
+          sendDisabled={true}
+          onCancel={vi.fn()}
+          onSteer={vi.fn()}
+          canSteer={false}
+        />
+      )
+      expect(screen.queryByTestId('steer-hint')).not.toBeInTheDocument()
+      expect(
+        screen.queryByPlaceholderText('chat:input.steerPlaceholder')
+      ).not.toBeInTheDocument()
+    })
+  })
 })

--- a/apps/web/src/components/__tests__/ToolResultCard.test.tsx
+++ b/apps/web/src/components/__tests__/ToolResultCard.test.tsx
@@ -99,6 +99,13 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+// ToolResultCard imports the real i18n singleton (for i18n.language in the
+// quote helper); stub it so the module's initReactI18next side effect does not
+// run under the partial react-i18next mock.
+vi.mock('../../lib/i18n', () => ({
+  default: { language: 'zh' },
+}))
+
 describe('ToolResultCard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -690,5 +697,83 @@ describe('ToolResultCard', () => {
       <ToolResultCard type={'unknown' as 'tool_call' | 'tool_result' | 'conflict'} />
     )
     expect(container.firstChild).toBeNull()
+  })
+
+  describe('Tool Result (parallel_execute)', () => {
+    const parallelResult = {
+      execution_id: 'par-1',
+      total_tasks: 2,
+      completed: 1,
+      failed: 1,
+      any_failed: true,
+      tasks: [
+        {
+          id: 't0',
+          type: 'edit_file',
+          description: '编辑第一章',
+          status: 'completed',
+          result: {},
+          error: null,
+        },
+        {
+          id: 't1',
+          type: 'delete_file',
+          description: '删除草稿',
+          status: 'failed',
+          result: null,
+          error: 'File not found',
+        },
+      ],
+    }
+
+    it('renders each sub-task description', () => {
+      render(
+        <ToolResultCard
+          type="tool_result"
+          toolName="parallel_execute"
+          result={parallelResult}
+        />
+      )
+      expect(screen.getByText('编辑第一章')).toBeInTheDocument()
+      expect(screen.getByText('删除草稿')).toBeInTheDocument()
+    })
+
+    it('surfaces a failed sub-task error (partial failure is visible)', () => {
+      render(
+        <ToolResultCard
+          type="tool_result"
+          toolName="parallel_execute"
+          result={parallelResult}
+        />
+      )
+      expect(screen.getByText('File not found')).toBeInTheDocument()
+    })
+
+    it('renders all-success runs without an error row', () => {
+      render(
+        <ToolResultCard
+          type="tool_result"
+          toolName="parallel_execute"
+          result={{
+            execution_id: 'par-2',
+            total_tasks: 1,
+            completed: 1,
+            failed: 0,
+            any_failed: false,
+            tasks: [
+              {
+                id: 't0',
+                type: 'query_files',
+                description: '检索资料',
+                status: 'completed',
+                result: {},
+                error: null,
+              },
+            ],
+          }}
+        />
+      )
+      expect(screen.getByText('检索资料')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/hooks/__tests__/useChatStreaming.test.ts
+++ b/apps/web/src/hooks/__tests__/useChatStreaming.test.ts
@@ -928,21 +928,51 @@ describe('useChatStreaming', () => {
         expect(result.current.streamRenderItems[0].content).toContain('chat:workflow.parallelStart')
       })
 
-      it('does not add stream nodes for parallel task start/end (noise reduction)', () => {
+      it('renders no node on parallel task start, one line on task end (live progress)', () => {
+        const { result } = renderHook(() => useChatStreaming())
+        const deps = createMockDeps()
+        const callbacks = result.current.getStreamCallbacks(deps)
+
+        // Task start only records the description; it renders no stream node.
+        act(() => {
+          callbacks.onParallelTaskStart?.('exec-1', 'task-1', 'tool_call', '章节检查')
+        })
+        act(() => {
+          vi.advanceTimersByTime(100)
+        })
+        expect(result.current.streamRenderItems).toHaveLength(0)
+
+        // Task end renders a single per-task completion line.
+        act(() => {
+          callbacks.onParallelTaskEnd?.('exec-1', 'task-1', 'completed')
+        })
+        act(() => {
+          vi.advanceTimersByTime(100)
+        })
+        expect(result.current.streamRenderItems).toHaveLength(1)
+        expect(result.current.streamRenderItems[0].type).toBe('thinking_status')
+        expect(result.current.streamRenderItems[0].content).toContain(
+          'chat:workflow.parallelTaskCompleted'
+        )
+      })
+
+      it('uses the failed label and includes the error on a failed parallel task', () => {
         const { result } = renderHook(() => useChatStreaming())
         const deps = createMockDeps()
         const callbacks = result.current.getStreamCallbacks(deps)
 
         act(() => {
-          callbacks.onParallelTaskStart?.('exec-1', 'task-1', 'tool_call', '章节检查')
-          callbacks.onParallelTaskEnd?.('exec-1', 'task-1', 'completed')
+          callbacks.onParallelTaskStart?.('exec-1', 'task-1', 'tool_call', '删除草稿')
+          callbacks.onParallelTaskEnd?.('exec-1', 'task-1', 'failed', undefined, 'File not found')
         })
-
         act(() => {
           vi.advanceTimersByTime(100)
         })
 
-        expect(result.current.streamRenderItems).toHaveLength(0)
+        expect(result.current.streamRenderItems).toHaveLength(1)
+        expect(result.current.streamRenderItems[0].content).toContain(
+          'chat:workflow.parallelTaskFailed'
+        )
       })
 
       it('adds thinking_status item for steering_received', () => {

--- a/apps/web/src/hooks/useChatStreaming.ts
+++ b/apps/web/src/hooks/useChatStreaming.ts
@@ -554,6 +554,13 @@ export function useChatStreaming(): UseChatStreamingReturn {
   const lastFlushTimeRef = useRef(0);
 
   /**
+   * Maps a parallel_execute sub-task id to its description, captured on
+   * task-start so task-end (which omits the description) can render a
+   * meaningful per-task completion line.
+   */
+  const parallelTaskDescRef = useRef<Map<string, string>>(new Map());
+
+  /**
    * Throttled flush function to update state from ref.
    * Limits state updates to at most once per STREAM_UPDATE_THROTTLE_MS,
    * reducing re-renders while ensuring the latest state is eventually flushed.
@@ -1064,9 +1071,15 @@ export function useChatStreaming(): UseChatStreamingReturn {
         ) => {
           if (
             status === "success" &&
-            ["create_file", "update_file", "delete_file", "edit_file"].includes(
-              toolName
-            )
+            [
+              "create_file",
+              "update_file",
+              "delete_file",
+              "edit_file",
+              // parallel_execute may create/edit/delete files across its
+              // sub-tasks, so its completion must also refresh the tree.
+              "parallel_execute",
+            ].includes(toolName)
           ) {
             // Coalesce multiple tool/file events into one refresh.
             scheduleFileTreeRefresh();
@@ -1278,21 +1291,40 @@ export function useChatStreaming(): UseChatStreamingReturn {
 
         onParallelTaskStart: (
           _executionId: string,
-          _taskId: string,
+          taskId: string,
           _taskType: string,
-          _description: string
+          description: string
         ) => {
-          // No-op: per-task status is verbose; keep summary events only.
+          // Remember the description so task-end can render a labeled line.
+          parallelTaskDescRef.current.set(taskId, description);
         },
 
         onParallelTaskEnd: (
           _executionId: string,
-          _taskId: string,
-          _status: string,
+          taskId: string,
+          status: string,
           _result?: unknown,
-          _error?: string
+          error?: string
         ) => {
-          // No-op: per-task status is verbose; keep summary events only.
+          const description =
+            parallelTaskDescRef.current.get(taskId) || taskId;
+          parallelTaskDescRef.current.delete(taskId);
+          const content =
+            status === "failed"
+              ? t('chat:workflow.parallelTaskFailed', {
+                  description,
+                  error: error || '',
+                })
+              : t('chat:workflow.parallelTaskCompleted', { description });
+          updateStreamItems((prev) => [
+            ...prev,
+            {
+              type: "thinking_status",
+              id: generateUniqueId("parallel-task-end"),
+              content,
+              timestamp: new Date(),
+            },
+          ]);
         },
 
         onParallelEnd: (_executionId: string, total: number, completed: number, failed: number, _durationMs: number) => {


### PR DESCRIPTION
## 背景

针对写作 agent 的两个困惑点——**并行执行 (`parallel_execute`)** 和 **追加消息 (steering)** 是否真的全链路接通——先做了一次多 agent 审计，结论是两者都「接了但实际没用」：

- **并行执行**：后端链路是通的，但 ① 没有任何 prompt 告诉模型这个工具存在 → 模型几乎不会调用；② 前端只渲染一个通用绿色卡片，不读 `tasks[]`、不刷新文件树、部分失败被吞；③ 一整套 `parallel_start/task/end` 事件前后端都有，却**从未被发出**（dead code）。
- **追加消息**：后端 `POST /agent/steer` + 队列 + 注入都活着，但 ① **前端没有任何入口**调用 `sendSteeringMessage`（孤儿代码）；② 被消费的 steering 消息**不写入历史**，下一轮即丢失。

本 PR 按既定方向改造，让两者真正可用。范围决策：**steering 采用 node-boundary**（保留后端注入时机，接通 UI + 持久化，并诚实标注「下一步生效」）；**并行执行做完整版（含实时进度）**。

## 改动

### 并行执行（真·可用 + 实时进度）
- **`core/progress_channel.py`（新）**：一个 contextvar 发射器。runner 在 `Runner.run_streamed` 前后安装它，使在 SDK 后台任务里执行的工具能把实时子事件「带出来」。
- **`parallel_executor.py`**：发出 `parallel_start / parallel_task_start / parallel_task_end / parallel_end`（复用 `core/events.py` 里原本是死代码的构造器）。信封保持 `success` 以让 `data.tasks[]` 通过 stream adapter，部分失败用 `data.any_failed/failed` + 每个子任务的 `status/error` 表达。
- **`runner.py`**：用一个共享队列把 SDK 事件（`_pump_sdk_events`）和进度事件交错排出；发射器只在 `run_streamed` 期间安装（SDK 同步建 task 时复制 context），避免跨 yield 的 contextvar token 问题。
- **前端**：`ToolResultCard` 新增真正的 `parallel_execute` 卡片（逐子任务状态/错误 + 部分失败配色）；`useChatStreaming` 把 `parallel_execute` 加入文件树刷新白名单，并把每个子任务完成渲染成实时进度行。
- **`prompts/base.py`**：告诉 planner/writer/hook_designer 何时用它（仅限相互独立的批量操作）。

### 追加消息（接通 UI + 持久化，node-boundary）
- **`ChatPanel` + `MessageInput`**：AI 生成中且有活跃 session 时，输入框保持可编辑，发送即派发 steering 消息（Enter 或专用按钮），并有诚实提示「将在下一步生效」。
- **`message_manager` + `service`**：把本轮实际消费的 steering 消息作为 user 轮次持久化到聊天历史，避免下一轮丢失。

## 测试与验证

- **后端**：`progress_channel`、并行进度发射（含部分失败）、runner pump、以及一个**忠实复现 contextvar 传播合流**的 runner 集成测试 + steering 注入；steering 历史持久化。`test_agent` 全量 **745 passed**，新增用例 **12 passed**，聚焦重跑 **101 passed**。
- **前端**：`ToolResultCard` 并行卡片、`MessageInput` steering 入口、`useChatStreaming` 每任务进度行。受影响文件 **271 passed**；`tsc -b` 与 ESLint 全绿。
- 顺带修复了 `ToolResultCard.test.tsx` 一个**既有的**套件加载失败（partial `react-i18next` mock 下 `lib/i18n` 初始化报错）。

## 备注
- 生产是 Railway + PostgreSQL，因此并行执行在生产确有并发（`_should_offload_tool_execution → is_postgres`）；SQLite 开发默认仍是顺序执行，但进度事件与结果卡片表现一致。
- steering 为 node-boundary（下一个 agent 步/handoff 生效），非「当前这轮实时打断」——UI 已据实标注。真正的 mid-turn 打断是更大的改动，未包含在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
