### PR TITLE
fix(agent): stop chat narration from being written into chapter files

### DIFF
--- a/apps/server/agent/core/stream_processor.py
+++ b/apps/server/agent/core/stream_processor.py
@@ -43,6 +43,22 @@ ESCAPED_FILE_PATTERNS = [
 # Buffer size limit (1MB)
 BUFFER_MAX_SIZE = 1024 * 1024
 
+# Turn-control / workflow markers that belong to the model's chat narration and
+# must never be persisted as file content. If an unterminated <file> body carries
+# one of these, it means chat text (handoff summaries, a trailing [TASK_COMPLETE],
+# cross-agent narration) leaked into the file-write state instead of real prose.
+CONTROL_MARKERS: tuple[str, ...] = (
+    "[task_complete]",
+    "[workflow_stopped]",
+    "[clarification_needed]",
+)
+
+
+def _contains_control_marker(text: str) -> bool:
+    """True when text carries a turn-control marker (i.e. chat narration, not prose)."""
+    lowered = text.lower()
+    return any(marker in lowered for marker in CONTROL_MARKERS)
+
 
 def normalize_file_markers(content: str) -> str:
     """
@@ -394,6 +410,28 @@ class StreamProcessor:
             final_content = self.content_buffer
             file_id = self.file_id
             content_length = len(final_content)
+
+            # Contamination guard: an unterminated <file> whose buffered body
+            # carries turn-control markers is chat narration / cross-agent
+            # handoff text that leaked into the file-write state — NOT chapter
+            # prose. Surface it as conversation and leave the (empty) file
+            # untouched rather than persisting the narration as the file's
+            # content. Legitimately truncated prose (no control marker) is still
+            # auto-completed below.
+            if _contains_control_marker(final_content):
+                log_with_context(
+                    logger,
+                    30,  # WARNING
+                    "Stream ended with an unterminated <file> containing control "
+                    "markers; discarding buffered narration instead of writing it "
+                    "to the file",
+                    project_id=self.project_id,
+                    user_id=self.user_id,
+                    file_id=file_id,
+                    content_length=content_length,
+                )
+                self.reset()
+                return StreamResult(conversation_content=final_content)
 
             log_with_context(
                 logger,

--- a/apps/server/agent/graph/writing_graph.py
+++ b/apps/server/agent/graph/writing_graph.py
@@ -28,6 +28,11 @@ from utils.logger import get_logger, log_with_context
 
 logger = get_logger(__name__)
 
+# Max times the workflow will re-run the writer to finish a file it created but
+# left empty (created via create_file but never completed the <file>…</file>
+# write). Bounded so a model that keeps failing cannot loop indefinitely.
+MAX_FILE_CORRECTION_ATTEMPTS = 2
+
 
 def _extract_review_payload(agent_content: str) -> str:
     """
@@ -239,6 +244,7 @@ async def run_writing_workflow_streaming(
     accumulated_content: str = ""  # Track content for auto-review threshold
     review_round: int = 0  # 跟踪 writer-quality_reviewer 循环次数
     previous_agent: str | None = None  # 跟踪上一个 agent
+    file_correction_attempts: int = 0  # 跟踪「创建了空文件但未写入正文」的纠正次数
 
     try:
         generation_mode = str(state.get("generation_mode") or "").strip().lower()
@@ -556,6 +562,53 @@ async def run_writing_workflow_streaming(
                 lowered = agent_content.lower()
                 if "<file" in lowered or "</file" in lowered:
                     writer_emitted_file_markers = True
+
+            # Corrective feedback for an abandoned file write.
+            #
+            # create_file makes an EMPTY file and sets a pending-empty-file guard
+            # that is cleared only when the model completes the <file>…</file>
+            # streaming write. If the guard is still set at this agent boundary,
+            # the model created a file but never wrote its body — it narrated
+            # instead, or dropped the closing </file>. Rather than ending the turn
+            # with an empty file (the StreamProcessor guard already prevents that
+            # narration from being persisted as the file's content), re-run the
+            # writer and explicitly tell it to finish the file. Bounded by
+            # MAX_FILE_CORRECTION_ATTEMPTS to avoid loops.
+            if (
+                not clarification_stopped
+                and not invalid_handoff_stopped
+                and not tool_call_exhausted
+                and iteration < max_iterations
+                and file_correction_attempts < MAX_FILE_CORRECTION_ATTEMPTS
+                and ToolContext.has_pending_empty_file()
+            ):
+                pending = ToolContext.get_pending_empty_file() or {}
+                pending_title = str(pending.get("title") or "未命名")
+                pending_file_id = str(pending.get("file_id") or pending.get("id") or "")
+                file_correction_attempts += 1
+                # Clear the guard now: the explicit instruction below replaces its
+                # blocking role, and leaving it set would re-trigger this branch
+                # even after edit_file fills the file (edit_file does not clear it).
+                ToolContext.clear_pending_empty_file()
+                log_with_context(
+                    logger,
+                    30,  # WARNING
+                    "Empty file detected after agent turn; re-running writer to complete it",
+                    file_id=pending_file_id,
+                    title=pending_title,
+                    attempt=file_correction_attempts,
+                )
+                id_hint = f"(id={pending_file_id})" if pending_file_id else ""
+                handoff_context = (
+                    f"[系统提醒] 你创建的文件《{pending_title}》{id_hint} 正文仍为空——"
+                    "上一轮没有用 <file>…</file> 完成流式写入（很可能漏了结尾的 </file>）。"
+                    "请立即调用 edit_file（id="
+                    f"{pending_file_id or '<该文件id>'}，op=append）把完整正文写入该文件；"
+                    "不要重复创建文件，也不要只在对话里复述正文。"
+                )
+                previous_agent = current_agent_type
+                current_agent_type = "writer"
+                continue
 
             # Structured clarification stop is canonical and must block planned/auto handoff.
             if clarification_stopped:

--- a/apps/server/agent/stream_adapter.py
+++ b/apps/server/agent/stream_adapter.py
@@ -354,6 +354,30 @@ class StreamAdapter:
             usage = data.get("usage")
             self._last_message_usage = usage if isinstance(usage, dict) else None
 
+            # Agent boundary. MESSAGE_END marks the end of ONE agent's turn; the
+            # same StreamAdapter/StreamProcessor is reused across the whole
+            # multi-agent handoff loop. If a file write is still open here, this
+            # agent created/opened a file but never closed it (no </file>), so
+            # finalize it NOW — otherwise the next handed-off agent's narration
+            # would keep accumulating into this agent's file and get flushed in
+            # at end-of-request. finalize_on_stream_end discards control-marker
+            # contaminated narration and salvages only genuine truncated prose.
+            #
+            # We deliberately leave the ToolContext pending-empty-file guard set:
+            # it is the signal the workflow loop uses to detect an unwritten file
+            # and re-run the writer to complete it (see writing_graph). It is
+            # cleared on a successful <file> completion or at full stream end.
+            if self.config.process_file_markers and self._stream_processor.is_active:
+                boundary_result = self._stream_processor.finalize_on_stream_end()
+                async for sse_event in self._emit_stream_result(boundary_result):
+                    yield sse_event
+                # NOTE: deliberately keep self._pending_file_write and the
+                # ToolContext pending-empty-file guard set. The StreamProcessor is
+                # now reset (no further cross-agent capture), but the guard remains
+                # the signal the workflow loop reads to re-run the writer, and the
+                # end-of-stream cleanup clears it so it cannot leak to the next
+                # request.
+
         elif event_type == StreamEventType.ERROR:
             # Error event
             error_msg = data.get("error", "Unknown error")

--- a/apps/server/tests/test_agent/test_stream_adapter.py
+++ b/apps/server/tests/test_agent/test_stream_adapter.py
@@ -1528,3 +1528,67 @@ async def test_abandoned_file_write_clears_pending_empty_file_guard():
 
     assert ToolContext.has_pending_empty_file() is False
     assert adapter._pending_file_write is None
+
+
+@pytest.mark.unit
+async def test_unterminated_file_with_control_marker_is_not_persisted():
+    """An unterminated <file> whose body carries a turn-control marker is chat
+    narration, not prose: it must NEVER be saved as the file's content.
+
+    This is the production corruption: the model opened <file>, streamed handoff
+    narration ending in [TASK_COMPLETE], and never closed it; the buffer must be
+    surfaced as conversation and the file left untouched.
+    """
+    from agent.stream_adapter import create_stream_adapter
+    from agent.tools.mcp_tools import ToolContext
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+    ToolContext.set_pending_empty_file("file-1", "第51章")
+    adapter.set_pending_file_write("file-1", "draft", "第51章")
+
+    async def mock_events():
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT,
+            data={"text": "<file>正文文件已创建，需直接写入内容。\n\n"},
+        )
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT,
+            data={"text": "### 交接审查完成，已交接给 writer。[TASK_COMPLETE]"},
+        )
+        yield LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={})
+
+    events = [e async for e in adapter.process_workflow_events(mock_events())]
+    event_types = [e.type for e in events]
+
+    # The narration must not be persisted as file content...
+    adapter._save_file_content.assert_not_awaited()
+    assert EventType.FILE_CONTENT_END not in event_types
+
+
+@pytest.mark.unit
+async def test_truncated_prose_without_control_marker_is_still_saved():
+    """Genuinely truncated prose (no </file>, no control markers) must still be
+    salvaged and saved — the contamination guard must not over-discard."""
+    from agent.stream_adapter import create_stream_adapter
+    from agent.tools.mcp_tools import ToolContext
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+    ToolContext.set_pending_empty_file("file-2", "第52章")
+    adapter.set_pending_file_write("file-2", "draft", "第52章")
+
+    async def mock_events():
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT,
+            data={"text": "<file>夜色沉沉，林川推开门，看见了那封信。"},
+        )
+        yield LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={})
+
+    _ = [e async for e in adapter.process_workflow_events(mock_events())]
+
+    adapter._save_file_content.assert_awaited_once()
+    saved_args = adapter._save_file_content.await_args.args
+    assert saved_args[0] == "file-2"
+    assert "夜色沉沉" in saved_args[1]
+    assert "[TASK_COMPLETE]" not in saved_args[1]

--- a/apps/server/tests/test_agent/test_writing_graph.py
+++ b/apps/server/tests/test_agent/test_writing_graph.py
@@ -754,3 +754,98 @@ class TestWritingGraphAutoReviewGate:
             for event in events
         )
         assert any(event.type == StreamEventType.WORKFLOW_COMPLETE for event in events)
+
+
+@pytest.mark.unit
+class TestWritingGraphFileCorrection:
+    """The workflow must re-run the writer when it leaves a created file empty."""
+
+    @pytest.mark.asyncio
+    async def test_empty_file_triggers_writer_rerun_with_correction(self):
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+
+        calls: list[dict] = []
+
+        async def fake_run_streaming_agent(state, agent_type, *_args, **_kwargs):
+            calls.append({"agent": agent_type, "user_message": state.get("user_message", "")})
+            if len(calls) == 1:
+                # Writer created an empty file (guard set) but only narrated and
+                # marked complete — it never streamed the <file> body.
+                ToolContext.set_pending_empty_file("file-X", "第51章")
+                yield StreamEvent(
+                    type=StreamEventType.TEXT,
+                    data={"text": "正文文件已创建，需直接写入内容。[TASK_COMPLETE]"},
+                )
+            else:
+                # Corrective re-run finishes the file (clears the guard).
+                ToolContext.clear_pending_empty_file()
+                yield StreamEvent(
+                    type=StreamEventType.TEXT,
+                    data={"text": "已用 edit_file 补全正文。[TASK_COMPLETE]"},
+                )
+
+        state = {"user_message": "写第51章", "messages": [], "system_prompt": ""}
+
+        ToolContext.set_context(
+            session=None, user_id="u", project_id="p", session_id="s",
+        )
+        try:
+            with (
+                patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+                patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+                patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+            ):
+                events = [
+                    event async for event in run_writing_workflow_streaming(
+                        state=state, thread_id="t",
+                    )
+                ]
+        finally:
+            ToolContext.clear_context()
+
+        # The writer must have run twice: the original turn + one correction.
+        assert len(calls) == 2
+        assert calls[0]["agent"] == "writer"
+        assert calls[1]["agent"] == "writer"
+        # The correction turn must carry the "file still empty / finish it" reminder.
+        assert "正文仍为空" in calls[1]["user_message"]
+        assert "edit_file" in calls[1]["user_message"]
+        # And the workflow still completes after the correction.
+        assert any(event.type == StreamEventType.WORKFLOW_COMPLETE for event in events)
+
+    @pytest.mark.asyncio
+    async def test_correction_is_bounded_and_does_not_loop_forever(self):
+        from agent.graph.writing_graph import MAX_FILE_CORRECTION_ATTEMPTS, run_writing_workflow_streaming
+
+        calls: list[str] = []
+
+        async def fake_run_streaming_agent(state, agent_type, *_args, **_kwargs):
+            calls.append(agent_type)
+            # Writer keeps creating empty files and never finishes one.
+            ToolContext.set_pending_empty_file("file-Y", "第52章")
+            yield StreamEvent(
+                type=StreamEventType.TEXT,
+                data={"text": "又创建了一个空文件。[TASK_COMPLETE]"},
+            )
+
+        state = {"user_message": "写第52章", "messages": [], "system_prompt": ""}
+
+        ToolContext.set_context(
+            session=None, user_id="u", project_id="p", session_id="s",
+        )
+        try:
+            with (
+                patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+                patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+                patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+            ):
+                _ = [
+                    event async for event in run_writing_workflow_streaming(
+                        state=state, thread_id="t",
+                    )
+                ]
+        finally:
+            ToolContext.clear_context()
+
+        # Initial turn + at most MAX_FILE_CORRECTION_ATTEMPTS corrective re-runs.
+        assert len(calls) <= 1 + MAX_FILE_CORRECTION_ATTEMPTS


### PR DESCRIPTION
## The bug (你看到的「乱写文件」)

After the agent-core optimization series merged, the writer began persisting its **own chat narration** into chapter files — handoff summaries, reasoning, and a trailing `[TASK_COMPLETE]` — instead of the novel prose. Server log signature: `Stream ended without </file>, auto-completing file write`.

## Root cause (verified)

One `StreamAdapter`/`StreamProcessor` is created per request and **reused across the whole multi-agent handoff loop, never reset between agents** (`StreamAdapter.reset()` has zero call sites). The model opened a `<file>` block but never closed it — it narrated / handed off instead of streaming prose (a behavior the new history breadcrumbs + `[TASK_COMPLETE]`-only completion made common) — so every later TEXT delta, **including the next agent's narration**, accumulated in the file buffer. `finalize_on_stream_end` then **unconditionally** persisted that buffer as the chapter's content.

`stream_processor.py` itself is unchanged vs. pre-optimization (`git diff 6c041e5..main` is empty) — this is a latent bug that the optimization destabilized into firing reliably.

## The fix — three layers

1. **Defensive — never persist narration** (`stream_processor.py`): the WRITING-state finalize now discards an unterminated `<file>` whose body carries turn-control markers (`[TASK_COMPLETE]` / `[workflow_stopped]` / `[clarification_needed]`) to conversation. Genuinely truncated prose (no marker) is still salvaged.
2. **Defensive — stop cross-agent leakage** (`stream_adapter.py`): finalize the StreamProcessor at each agent boundary (`MESSAGE_END`) so a handed-off agent's text can't accumulate into a prior agent's open file.
3. **Corrective — finish the file instead of failing silently** (`writing_graph.py`): when an agent leaves a created file empty, re-run the writer with an explicit *"you didn't finish the `<file>` write — complete it with `edit_file`"* reminder (your suggested 更合理 approach). Bounded by `MAX_FILE_CORRECTION_ATTEMPTS`.

## Tests
- `stream_adapter`: control-marker narration is **not** persisted; truncated prose **is** salvaged; abandoned-guard cleanup intact.
- `writing_graph`: the writer re-runs with the correction message, and the corrective loop stays bounded.
- Full agent suite: **737 passed, 4 skipped**.

## Note on the LLM question (separate)
I also audited every LLM call site for the "suggestions not on DeepSeek" report: **every chat-LLM already resolves to DeepSeek** (`LLMClient._resolve_model` rejects non-DeepSeek models; suggestions go through it). There is no non-DeepSeek chat-LLM in code, so nothing to switch — if suggestions hit a non-DeepSeek endpoint at runtime, it's the deployed `DEEPSEEK_BASE_URL` env pointing at a proxy. Not part of this PR. (Zhipu embeddings + Tencent ASR are intentionally non-DeepSeek and correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)