### PR TITLE
fix(agent): make steering queue cross-worker (Redis-backed)

### DIFF
--- a/apps/server/agent/core/steering.py
+++ b/apps/server/agent/core/steering.py
@@ -6,11 +6,14 @@ for mid-execution guidance.
 """
 
 import asyncio
+import json
+import os
 import re
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Final
+from typing import Any, Final
 
 from utils.logger import get_logger, log_with_context
 
@@ -233,36 +236,232 @@ class SteeringQueueManager:
                 )
 
 
-# Global queue manager instance
+# ---------------------------------------------------------------------------
+# Redis-backed steering (cross-worker)
+#
+# The in-memory SteeringQueueManager above only works within a SINGLE process.
+# Production runs multiple uvicorn workers (WEB_CONCURRENCY), so the worker that
+# serves POST /agent/steer is usually NOT the worker running the SSE stream that
+# created the queue — the lookup misses and the user gets a 404 "对话会话不存在".
+# When Redis is configured we keep the per-session owner + pending messages in
+# Redis so every worker sees the same queue. Dev without REDIS_URL falls back to
+# the in-memory manager, which is correct for a single worker.
+# ---------------------------------------------------------------------------
+
+_STEERING_TTL_S: Final[int] = 3600  # session keys expire after 1h of inactivity
+_REDIS_HEALTH_TTL_S: Final[float] = 30.0
+
+_redis_health_checked_at: float = 0.0
+_redis_is_healthy: bool = False
+
+
+def _owner_key(session_id: str) -> str:
+    return f"steering:owner:{session_id}"
+
+
+def _msgs_key(session_id: str) -> str:
+    return f"steering:msgs:{session_id}"
+
+
+def _redis_available_sync() -> bool:
+    """Whether to use Redis for steering (configured + reachable), cached briefly."""
+    global _redis_health_checked_at, _redis_is_healthy
+    # Mirror the rate-limiter's "auto" rule: only use Redis when explicitly
+    # configured, so dev without a local Redis doesn't pay a connect timeout.
+    if not os.getenv("REDIS_URL"):
+        return False
+    now = time.monotonic()
+    if now < _redis_health_checked_at + _REDIS_HEALTH_TTL_S:
+        return _redis_is_healthy
+    try:
+        from services.infra.redis_client import get_redis_client
+
+        get_redis_client().ping()
+        healthy = True
+    except Exception as exc:  # noqa: BLE001 — any failure means fall back to memory
+        healthy = False
+        log_with_context(
+            logger,
+            30,  # WARNING
+            "Steering Redis unavailable; falling back to in-memory queue "
+            "(cross-worker steering will not work under multiple workers)",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+    _redis_is_healthy = healthy
+    _redis_health_checked_at = now
+    return healthy
+
+
+async def _redis_available() -> bool:
+    return await asyncio.to_thread(_redis_available_sync)
+
+
+def _parse_created_at(raw: Any) -> datetime:
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            pass
+    return datetime.now()
+
+
+class RedisSteeringQueue:
+    """Steering queue backed by Redis so all workers share the same messages."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+    async def add(self, content: str) -> SteeringMessage:
+        sanitized = sanitize_steering_content(content)
+        msg = SteeringMessage(
+            id=f"steer-{datetime.now().timestamp()}",
+            content=sanitized,
+            created_at=datetime.now(),
+        )
+        await asyncio.to_thread(self._add_sync, msg)
+        log_with_context(
+            logger, 20, "Steering message added (redis)",
+            session_id=self.session_id, message_id=msg.id,
+            content_preview=sanitized[:50],
+        )
+        return msg
+
+    def _add_sync(self, msg: SteeringMessage) -> None:
+        from services.infra.redis_client import get_redis_client
+
+        client = get_redis_client()
+        payload = json.dumps(
+            {"id": msg.id, "content": msg.content, "created_at": msg.created_at.isoformat()}
+        )
+        pipe = client.pipeline()
+        pipe.rpush(_msgs_key(self.session_id), payload)
+        pipe.expire(_msgs_key(self.session_id), _STEERING_TTL_S)
+        pipe.expire(_owner_key(self.session_id), _STEERING_TTL_S)
+        pipe.execute()
+
+    async def get_pending(self) -> list[SteeringMessage]:
+        raws = await asyncio.to_thread(self._pop_all_sync)
+        messages = [m for m in (self._deserialize(raw) for raw in raws) if m is not None]
+        if messages:
+            log_with_context(
+                logger, 20, "Steering messages retrieved (redis)",
+                session_id=self.session_id, count=len(messages),
+            )
+        return messages
+
+    def _pop_all_sync(self) -> list[str]:
+        from services.infra.redis_client import get_redis_client
+
+        client = get_redis_client()
+        # Atomically read all queued messages and clear them in one transaction.
+        pipe = client.pipeline(transaction=True)
+        pipe.lrange(_msgs_key(self.session_id), 0, -1)
+        pipe.delete(_msgs_key(self.session_id))
+        results = pipe.execute()
+        return list(results[0] or [])
+
+    async def peek(self) -> list[SteeringMessage]:
+        raws = await asyncio.to_thread(self._peek_sync)
+        return [m for m in (self._deserialize(raw) for raw in raws) if m is not None]
+
+    def _peek_sync(self) -> list[str]:
+        from services.infra.redis_client import get_redis_client
+
+        return list(get_redis_client().lrange(_msgs_key(self.session_id), 0, -1) or [])
+
+    async def clear(self) -> None:
+        from services.infra.redis_client import get_redis_client
+
+        await asyncio.to_thread(lambda: get_redis_client().delete(_msgs_key(self.session_id)))
+
+    @staticmethod
+    def _deserialize(raw: str) -> SteeringMessage | None:
+        try:
+            data = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        content = str(data.get("content") or "")
+        if not content:
+            return None
+        return SteeringMessage(
+            id=str(data.get("id") or ""),
+            content=content,
+            created_at=_parse_created_at(data.get("created_at")),
+            processed=True,
+            processed_at=datetime.now(),
+        )
+
+
+def _redis_create_sync(session_id: str, owner_user_id: str | None) -> None:
+    from services.infra.redis_client import get_redis_client
+
+    # The session owner starts the stream they own (session_id is their
+    # chat_session.id), so binding the owner here is authoritative.
+    get_redis_client().set(_owner_key(session_id), owner_user_id or "", ex=_STEERING_TTL_S)
+
+
+def _redis_get_owner_sync(session_id: str) -> str | None:
+    from services.infra.redis_client import get_redis_client
+
+    return get_redis_client().get(_owner_key(session_id))
+
+
+def _redis_backfill_owner_sync(session_id: str, user_id: str) -> None:
+    from services.infra.redis_client import get_redis_client
+
+    # xx=True: only set when the key still exists (don't resurrect a cleaned session).
+    get_redis_client().set(_owner_key(session_id), user_id, ex=_STEERING_TTL_S, xx=True)
+
+
+def _redis_cleanup_sync(session_id: str) -> None:
+    from services.infra.redis_client import get_redis_client
+
+    get_redis_client().delete(_owner_key(session_id), _msgs_key(session_id))
+
+
+# Global in-memory queue manager (fallback for single-worker / no-Redis dev).
 _queue_manager = SteeringQueueManager()
 
 
-async def get_steering_queue_async(session_id: str) -> SteeringQueue:
-    """
-    Get or create steering queue for a session (async version).
-
-    This is the recommended method for new code.
-    """
+async def get_steering_queue_async(session_id: str) -> Any:
+    """Get or create steering queue for a session (async version)."""
+    if await _redis_available():
+        await asyncio.to_thread(_redis_create_sync, session_id, None)
+        return RedisSteeringQueue(session_id)
     return await _queue_manager.get_queue(session_id)
 
 
 async def create_steering_queue_async(
     session_id: str,
     owner_user_id: str | None,
-) -> SteeringQueue:
+) -> Any:
     """Create/get queue and bind ownership when available."""
+    if await _redis_available():
+        await asyncio.to_thread(_redis_create_sync, session_id, owner_user_id)
+        return RedisSteeringQueue(session_id)
     return await _queue_manager.get_queue(session_id, owner_user_id=owner_user_id)
 
 
-async def get_steering_queue_for_user_async(session_id: str, user_id: str) -> SteeringQueue:
-    """Get existing queue for a specific user without creating new session queues."""
+async def get_steering_queue_for_user_async(session_id: str, user_id: str) -> Any:
+    """Get an existing queue for a user; KeyError if absent, PermissionError on mismatch."""
+    if await _redis_available():
+        owner = await asyncio.to_thread(_redis_get_owner_sync, session_id)
+        if owner is None:
+            raise KeyError(session_id)
+        if owner and owner != user_id:
+            raise PermissionError(
+                f"Steering session {session_id} does not belong to user {user_id}"
+            )
+        if not owner:
+            await asyncio.to_thread(_redis_backfill_owner_sync, session_id, user_id)
+        return RedisSteeringQueue(session_id)
     return await _queue_manager.get_queue_for_user(session_id, user_id)
 
 
 async def cleanup_steering_queue_async(session_id: str) -> None:
-    """
-    Remove steering queue for a session (async version).
-
-    This is the recommended method for new code.
-    """
+    """Remove steering queue for a session (async version)."""
+    if await _redis_available():
+        await asyncio.to_thread(_redis_cleanup_sync, session_id)
+        return
     await _queue_manager.cleanup(session_id)

--- a/apps/server/tests/test_agent/test_steering_redis.py
+++ b/apps/server/tests/test_agent/test_steering_redis.py
@@ -1,0 +1,175 @@
+"""Tests for the Redis-backed (cross-worker) steering queue.
+
+These simulate the production failure mode: the worker serving POST /agent/steer
+is a different process from the one running the SSE stream. With the in-memory
+queue that lookup misses (404 "对话会话不存在"); with Redis both workers share state.
+"""
+
+import pytest
+
+
+class FakePipeline:
+    def __init__(self, client):
+        self.client = client
+        self.ops: list[tuple[str, tuple]] = []
+
+    def rpush(self, *args):
+        self.ops.append(("rpush", args))
+        return self
+
+    def lrange(self, *args):
+        self.ops.append(("lrange", args))
+        return self
+
+    def delete(self, *args):
+        self.ops.append(("delete", args))
+        return self
+
+    def expire(self, *args):
+        self.ops.append(("expire", args))
+        return self
+
+    def execute(self):
+        results = [getattr(self.client, name)(*args) for name, args in self.ops]
+        self.ops = []
+        return results
+
+
+class FakeRedis:
+    """Minimal in-process Redis stand-in shared across "workers" in a test."""
+
+    def __init__(self):
+        self.store: dict = {}
+
+    def ping(self):
+        return True
+
+    def set(self, key, value, ex=None, xx=False, nx=False):
+        if xx and key not in self.store:
+            return None
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        v = self.store.get(key)
+        return v if isinstance(v, str) else None
+
+    def delete(self, *keys):
+        n = 0
+        for k in keys:
+            if k in self.store:
+                del self.store[k]
+                n += 1
+        return n
+
+    def rpush(self, key, *vals):
+        lst = self.store.get(key)
+        if not isinstance(lst, list):
+            lst = []
+            self.store[key] = lst
+        lst.extend(vals)
+        return len(lst)
+
+    def lrange(self, key, start, end):
+        lst = self.store.get(key, [])
+        if not isinstance(lst, list):
+            return []
+        return list(lst[start:]) if end == -1 else list(lst[start : end + 1])
+
+    def expire(self, key, ttl):
+        return key in self.store
+
+    def pipeline(self, transaction=True):
+        return FakePipeline(self)
+
+
+@pytest.fixture
+def redis_steering(monkeypatch):
+    """Route steering through a single shared FakeRedis and force the Redis path."""
+    import agent.core.steering as st
+
+    fake = FakeRedis()
+    monkeypatch.setenv("REDIS_URL", "redis://fake:6379/0")
+    monkeypatch.setattr(
+        "services.infra.redis_client.get_redis_client", lambda: fake, raising=True
+    )
+    # Force a fresh health check (and that it resolves to "healthy").
+    st._redis_health_checked_at = 0.0
+    st._redis_is_healthy = False
+    return st, fake
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_steering_message_crosses_workers(redis_steering):
+    st, _fake = redis_steering
+
+    # Worker A (the SSE stream) creates the queue.
+    queue_a = await st.create_steering_queue_async("sess-1", "user-1")
+    assert isinstance(queue_a, st.RedisSteeringQueue)
+
+    # Worker B (a DIFFERENT process serving POST /steer) finds the same session
+    # and enqueues a steering message.
+    queue_b = await st.get_steering_queue_for_user_async("sess-1", "user-1")
+    assert isinstance(queue_b, st.RedisSteeringQueue)
+    await queue_b.add("把主角改名为林川")
+
+    # Worker A's running stream drains what worker B added — the whole point.
+    pending = await queue_a.get_pending()
+    assert [m.content for m in pending] == ["把主角改名为林川"]
+
+    # Draining is destructive: a second poll is empty.
+    assert await queue_a.get_pending() == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unknown_session_raises_keyerror(redis_steering):
+    st, _fake = redis_steering
+    # No create_* call -> the /steer endpoint must get KeyError (-> 404), not crash.
+    with pytest.raises(KeyError):
+        await st.get_steering_queue_for_user_async("does-not-exist", "user-1")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_owner_mismatch_raises_permissionerror(redis_steering):
+    st, _fake = redis_steering
+    await st.create_steering_queue_async("sess-2", "owner-user")
+    with pytest.raises(PermissionError):
+        await st.get_steering_queue_for_user_async("sess-2", "attacker-user")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_removes_session(redis_steering):
+    st, fake = redis_steering
+    await st.create_steering_queue_async("sess-3", "user-1")
+    q = await st.get_steering_queue_for_user_async("sess-3", "user-1")
+    await q.add("msg")
+    await st.cleanup_steering_queue_async("sess-3")
+    # After cleanup the session no longer exists.
+    assert fake.store == {}
+    with pytest.raises(KeyError):
+        await st.get_steering_queue_for_user_async("sess-3", "user-1")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_falls_back_to_memory_without_redis_url(monkeypatch):
+    """No REDIS_URL -> in-memory path (correct for a single-worker dev server)."""
+    import agent.core.steering as st
+
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    st._redis_health_checked_at = 0.0
+    st._redis_is_healthy = False
+
+    queue = await st.create_steering_queue_async("sess-mem", "user-1")
+    assert isinstance(queue, st.SteeringQueue)  # in-memory, not RedisSteeringQueue
+    await queue.add("hi")
+    same = await st.get_steering_queue_for_user_async("sess-mem", "user-1")
+    pending = await same.get_pending()
+    assert [m.content for m in pending] == ["hi"]
+    await st.cleanup_steering_queue_async("sess-mem")


### PR DESCRIPTION
## The bug
"追加消息" (steering) returns **404 "对话会话不存在"** (`CHAT_SESSION_NOT_FOUND`):
```
Failed to send steering message Error: 对话会话不存在
POST /api/v1/agent/steer 404
```

## Root cause
The steering queue (`SteeringQueueManager._queues`) is an **in-memory, process-local dict**, but production runs `uvicorn --workers ${WEB_CONCURRENCY:-3}` → **3 separate processes**:
- `POST /agent/stream` (the SSE stream) creates the queue in **worker A's** memory.
- `POST /agent/steer` is a *separate* request → load-balanced to **worker B/C**, which has no such queue → `KeyError` → 404.

With 3 workers, `/steer` misses ~2/3 of the time. The in-memory queue was always multi-worker-broken; it only surfaced now that the steering UI actually calls `/steer`.

## Fix
Back the steering queue with **Redis** so all workers share it:
- `steering:owner:{session_id}` (ownership) + `steering:msgs:{session_id}` (a list), 1h TTL refreshed on activity.
- `get_pending()` pops-all atomically (`LRANGE`+`DEL` in one `MULTI`).
- Routing mirrors the existing rate-limiter **"auto"** rule: use Redis only when `REDIS_URL` is set **and** reachable; otherwise fall back to the in-memory manager (correct for a single-worker dev server).

The public API + `SteeringQueue` duck-type are unchanged, so `service.py` and `api/agent.py` need **no** changes. `redis` is already a dependency (email verification uses the same client).

## Requirements / mitigation
- **Prod must have `REDIS_URL` set** (it already does — email verification uses this Redis client). Once deployed, steering works across all workers.
- **Immediate mitigation without deploying:** set `WEB_CONCURRENCY=1` (single worker → in-memory works).

## Tests
`test_steering_redis.py` (new) with a `FakeRedis` proves a message enqueued on "worker B" is drained by the stream on "worker A", plus `KeyError`/`PermissionError`/cleanup and the no-`REDIS_URL` in-memory fallback. Existing 48 steering tests still pass. **Full agent suite: 742 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)