### PR TITLE
fix(prefect): prevent Railway worker package corruption

### DIFF
--- a/apps/server/docker/Dockerfile.prefect-worker
+++ b/apps/server/docker/Dockerfile.prefect-worker
@@ -13,14 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # 复制依赖文件
 COPY apps/server/requirements.txt .
 
-# 安装 Python 依赖
-RUN pip install --no-cache-dir -r requirements.txt
-
-# 安装 Prefect 和数据库驱动
-# importlib-metadata is required by prefect 3.4.19 on Python < 3.12. requirements.txt
-# pulls a newer prefect, and downgrading here to 3.4.19 can leave it uninstalled, so
-# install it explicitly to avoid the worker crashing with ModuleNotFoundError.
-RUN pip install --no-cache-dir prefect==3.4.19 psycopg2-binary asyncpg importlib-metadata
+# 安装 Python 依赖。Prefect 和数据库驱动已在 requirements.txt 中声明；必须在
+# 同一次解析中安装，避免先安装新版 Prefect、再降级后形成新旧文件混装。
+# 构建时执行 CLI，使损坏的 Prefect 安装在部署前直接失败。
+RUN pip install --no-cache-dir -r requirements.txt \
+    && prefect version
 
 # 复制应用代码
 COPY apps/server/ .

--- a/apps/server/requirements.txt
+++ b/apps/server/requirements.txt
@@ -15,8 +15,13 @@ openai>=2.36.0,<2.44
 openai-agents>=0.17.6,<0.18
 
 
-# Prefect for workflow orchestration
-prefect>=3.4.0
+# Prefect for workflow orchestration. Keep this aligned with prefect.yaml and the
+# Prefect server image: the worker must not install a newer release and then
+# downgrade it, because that can leave incompatible package files behind.
+prefect==3.4.19
+# Prefect 3.4.19 imports this backport in its worker CLI on Python 3.11 even though
+# its package metadata only declares it for older Python versions.
+importlib-metadata>=4.4
 
 # Zhipu AI (embeddings)
 # Provides `from zai import ZhipuAiClient`

--- a/apps/server/tests/test_prefect_worker_image.py
+++ b/apps/server/tests/test_prefect_worker_image.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_prefect_worker_installs_one_pinned_prefect_version():
+    requirements = (SERVER_ROOT / "requirements.txt").read_text()
+    worker_dockerfile = (SERVER_ROOT / "docker" / "Dockerfile.prefect-worker").read_text()
+
+    prefect_requirements = [
+        line.strip() for line in requirements.splitlines() if line.strip().startswith("prefect")
+    ]
+
+    assert prefect_requirements == ["prefect==3.4.19"]
+    assert any(line.strip().startswith("importlib-metadata") for line in requirements.splitlines())
+    assert "pip install --no-cache-dir prefect" not in worker_dockerfile
+
+
+def test_prefect_worker_checks_the_cli_during_image_build():
+    worker_dockerfile = (SERVER_ROOT / "docker" / "Dockerfile.prefect-worker").read_text()
+
+    assert "prefect version" in worker_dockerfile


### PR DESCRIPTION
## Summary

- pin the shared Prefect dependency to the 3.4.19 version used by `prefect.yaml` and the server image
- remove the worker image's second, downgrade-style Prefect installation
- retain the Python 3.11 `importlib-metadata` runtime requirement
- import the Prefect CLI during image build and add static regression coverage

## Root cause

`requirements.txt` first resolved a newer Prefect release, while the next Docker layer downgraded it to 3.4.19. The Railway traceback showed the resulting incompatible package layout: newer `prefect.utilities.engine` code importing `opaque` from the older 3.4.19 annotations module.

## Verification

- clean Python 3.11 install of all 205 requirements
- `prefect version`
- `prefect worker start --help`
- all five `prefect.yaml` deployment entrypoints imported under Python 3.11
- `uv pip check`: compatible
- flow/deployment suite: 72 passed
- targeted regression: 2 passed
- Ruff, Pylint, and `git diff --check`: passed
- full backend suite reached 2500 passed / 14 skipped; one unrelated UTC-midnight-sensitive legacy test failed

## Risk / Rollback

Narrow dependency/build change. Roll back this commit to restore the former two-step install, though doing so reintroduces the mixed-version failure mode.
