### PR TITLE
深度 review 修复: 写作 Agent 子系统 23 项确认缺陷

### DIFF
--- a/apps/server/agent/context/prioritizer.py
+++ b/apps/server/agent/context/prioritizer.py
@@ -24,12 +24,52 @@ class ContextPrioritizer:
         """Initialize prioritizer with default rules."""
         pass
 
-    def classify_priority(self, item: ContextItem) -> ContextPriority:
+    @staticmethod
+    def _is_user_attached(item: ContextItem) -> bool:
+        """Whether the user explicitly attached/quoted this item."""
+        metadata = item.metadata or {}
+        return bool(metadata.get("attached") or metadata.get("is_quote"))
+
+    @classmethod
+    def _intent_rank(cls, item: ContextItem) -> int:
+        """
+        Ordering rank inside a priority group: user intent before relevance.
+
+        组内顺序决定预算耗尽时谁被截断/丢弃，因此焦点文件必须排在最前
+        （否则 query recall 加成可能把相关度抬到 1.0 以上的其他条目排到
+        焦点之前），其次是用户显式附加/引用的内容。
+        """
+        if item.is_focus:
+            return 0
+        return 1 if cls._is_user_attached(item) else 2
+
+    @classmethod
+    def _allows_parent_upgrade(cls, items: list[ContextItem]) -> bool:
+        """
+        父大纲能否升级到 CRITICAL：批次里没有用户显式附加/引用的内容时才可以。
+
+        升级的唯一目的是借用 TokenBudget.select_items 里 CRITICAL 的池化预算；
+        但池化额度本来就是留给用户显式附加内容的，一旦两者同处 CRITICAL，
+        相关度更高的父大纲会把附加文件截断甚至整体挤出上下文。此时让父大纲
+        留在 CONSTRAINT 档，它仍有该档的保底份额。
+        """
+        return not any(
+            cls._is_user_attached(item) and not item.is_focus for item in items
+        )
+
+    def classify_priority(
+        self,
+        item: ContextItem,
+        *,
+        allow_parent_upgrade: bool = True,
+    ) -> ContextPriority:
         """
         Classify the priority of a context item.
 
         Args:
             item: Context item to classify
+            allow_parent_upgrade: Whether relation="parent" outlines may be
+                upgraded to CRITICAL (see _allows_parent_upgrade)
 
         Returns:
             ContextPriority level
@@ -38,12 +78,23 @@ class ContextPrioritizer:
         if item.is_focus:
             return ContextPriority.CRITICAL
 
-        # Priority already set
-        if item.priority != ContextPriority.INSPIRATION:
-            return item.priority
+        # Type/relation rules may upgrade a preset priority (e.g. parent
+        # outlines carry whole-story background and must reach CRITICAL so
+        # they can draw on the pooled budget in TokenBudget.select_items),
+        # but never downgrade one — user-attached files and retrieval
+        # snippets keep the tier the assembler explicitly assigned.
+        type_priority = self._classify_by_type(item)
 
-        # Classify based on type and metadata
-        return self._classify_by_type(item)
+        # CRITICAL 是 _classify_by_type 里唯一的升级目标（relation="parent"）；
+        # 拒绝升级时退到 CONSTRAINT（与 sibling/child 同档）而不是回落到预设，
+        # 以保持"只升不降"不变式。
+        if not allow_parent_upgrade and type_priority == ContextPriority.CRITICAL:
+            type_priority = ContextPriority.CONSTRAINT
+
+        order = ContextPriority.priority_order()
+        if order.index(type_priority) < order.index(item.priority):
+            return type_priority
+        return item.priority
 
     def _classify_by_type(self, item: ContextItem) -> ContextPriority:
         """Classify based on item type and metadata."""
@@ -96,8 +147,11 @@ class ContextPrioritizer:
             Sorted list (highest priority first)
         """
         # Assign priorities
+        allow_parent_upgrade = self._allows_parent_upgrade(items)
         for item in items:
-            item.priority = self.classify_priority(item)
+            item.priority = self.classify_priority(
+                item, allow_parent_upgrade=allow_parent_upgrade
+            )
 
         # Priority order
         priority_order = {
@@ -109,8 +163,9 @@ class ContextPrioritizer:
 
         # Sort by:
         # 1. Priority (CRITICAL first)
-        # 2. Relevance score (higher first)
-        # 3. Type (outline > snippet > character > lore)
+        # 2. User intent (focus, then user-attached/quoted content)
+        # 3. Relevance score (higher first)
+        # 4. Type (outline > snippet > character > lore)
         type_order = {
             "outline": 0,
             "snippet": 1,
@@ -122,6 +177,7 @@ class ContextPrioritizer:
             items,
             key=lambda x: (
                 priority_order.get(x.priority, 4),
+                self._intent_rank(x),
                 -(x.relevance_score or 0),
                 type_order.get(x.type, 4),
             )
@@ -144,14 +200,18 @@ class ContextPrioritizer:
             p: [] for p in ContextPriority
         }
 
+        allow_parent_upgrade = self._allows_parent_upgrade(items)
         for item in items:
-            priority = self.classify_priority(item)
+            priority = self.classify_priority(
+                item, allow_parent_upgrade=allow_parent_upgrade
+            )
             groups[priority].append(item)
 
-        # Sort within each group by relevance
+        # Sort within each group by user intent, then relevance.
+        # TokenBudget.select_items 按这个顺序花预算，靠后的条目才会被截断/丢弃。
         for priority in groups:
             groups[priority].sort(
-                key=lambda x: -(x.relevance_score or 0)
+                key=lambda x: (self._intent_rank(x), -(x.relevance_score or 0))
             )
 
         return groups

--- a/apps/server/agent/core/steering.py
+++ b/apps/server/agent/core/steering.py
@@ -133,6 +133,10 @@ class SteeringQueueEntry:
 
     queue: SteeringQueue
     owner_user_id: str | None = None
+    # 同一 chat session 的并发 stream run 共享同一个队列，但生命周期以 run
+    # 为单位：cleanup 只在最后一个持有 run 释放后才真正删除队列，避免先结
+    # 束的 run 删掉另一个仍在流式生成的 run 正在使用的队列。
+    active_run_ids: set[str] = field(default_factory=set)
 
 
 class SteeringQueueManager:
@@ -151,6 +155,7 @@ class SteeringQueueManager:
         session_id: str,
         owner_user_id: str | None = None,
         create_if_missing: bool = True,
+        run_id: str | None = None,
     ) -> SteeringQueue:
         """Get or create steering queue for a session."""
         async with self._lock:
@@ -199,6 +204,9 @@ class SteeringQueueManager:
                     owner_user_id=owner_user_id,
                 )
 
+            if run_id:
+                entry.active_run_ids.add(run_id)
+
             return entry.queue
 
     async def get_queue_for_user(self, session_id: str, user_id: str) -> SteeringQueue:
@@ -223,17 +231,34 @@ class SteeringQueueManager:
                 )
             return entry.queue
 
-    async def cleanup(self, session_id: str) -> None:
-        """Remove steering queue for a session."""
+    async def cleanup(self, session_id: str, run_id: str | None = None) -> None:
+        """Release a run's hold on the queue; delete only when no runs remain.
+
+        run_id 为 None 时保持旧语义：无条件删除整个队列。
+        """
         async with self._lock:
-            if session_id in self._queues:
-                del self._queues[session_id]
-                log_with_context(
-                    logger,
-                    20,  # INFO
-                    "Steering queue cleaned up for session",
-                    session_id=session_id,
-                )
+            entry = self._queues.get(session_id)
+            if entry is None:
+                return
+            if run_id is not None:
+                entry.active_run_ids.discard(run_id)
+                if entry.active_run_ids:
+                    log_with_context(
+                        logger,
+                        20,  # INFO
+                        "Steering queue retained; other runs still active",
+                        session_id=session_id,
+                        run_id=run_id,
+                        active_runs=len(entry.active_run_ids),
+                    )
+                    return
+            del self._queues[session_id]
+            log_with_context(
+                logger,
+                20,  # INFO
+                "Steering queue cleaned up for session",
+                session_id=session_id,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +286,10 @@ def _owner_key(session_id: str) -> str:
 
 def _msgs_key(session_id: str) -> str:
     return f"steering:msgs:{session_id}"
+
+
+def _runs_key(session_id: str) -> str:
+    return f"steering:runs:{session_id}"
 
 
 def _redis_available_sync() -> bool:
@@ -338,6 +367,7 @@ class RedisSteeringQueue:
         pipe.rpush(_msgs_key(self.session_id), payload)
         pipe.expire(_msgs_key(self.session_id), _STEERING_TTL_S)
         pipe.expire(_owner_key(self.session_id), _STEERING_TTL_S)
+        pipe.expire(_runs_key(self.session_id), _STEERING_TTL_S)
         pipe.execute()
 
     async def get_pending(self) -> list[SteeringMessage]:
@@ -355,14 +385,18 @@ class RedisSteeringQueue:
 
         client = get_redis_client()
         # Atomically read all queued messages and clear them in one transaction.
-        # get_pending() is polled at every node/tool boundary, so refreshing the
-        # owner key's TTL here acts as a poll-driven heartbeat that keeps the
-        # session alive for the whole stream instead of letting it expire after
-        # the fixed 1h TTL mid-run (which would 404 subsequent steering posts).
+        # get_pending() is polled when an agent run starts (initial injection),
+        # at tool-output boundaries inside a run, at agent boundaries in the
+        # workflow graph, and once more before the stream saves history, so
+        # refreshing the owner/runs key TTLs here acts as a poll-driven
+        # heartbeat that keeps the session alive for the whole stream instead
+        # of letting it expire after the fixed 1h TTL mid-run (which would 404
+        # subsequent steering posts).
         pipe = client.pipeline(transaction=True)
         pipe.lrange(_msgs_key(self.session_id), 0, -1)
         pipe.delete(_msgs_key(self.session_id))
         pipe.expire(_owner_key(self.session_id), _STEERING_TTL_S)
+        pipe.expire(_runs_key(self.session_id), _STEERING_TTL_S)
         results = pipe.execute()
         return list(results[0] or [])
 
@@ -398,12 +432,22 @@ class RedisSteeringQueue:
         )
 
 
-def _redis_create_sync(session_id: str, owner_user_id: str | None) -> None:
+def _redis_create_sync(
+    session_id: str,
+    owner_user_id: str | None,
+    run_id: str | None = None,
+) -> None:
     from services.infra.redis_client import get_redis_client
 
     # The session owner starts the stream they own (session_id is their
     # chat_session.id), so binding the owner here is authoritative.
-    get_redis_client().set(_owner_key(session_id), owner_user_id or "", ex=_STEERING_TTL_S)
+    client = get_redis_client()
+    client.set(_owner_key(session_id), owner_user_id or "", ex=_STEERING_TTL_S)
+    if run_id:
+        # 记录持有队列的 run：同一 session 的并发 run 共享 owner/msgs 键，
+        # cleanup 只在最后一个 run 释放时才真正删除（见 _RELEASE_RUN_SCRIPT）。
+        client.sadd(_runs_key(session_id), run_id)
+        client.expire(_runs_key(session_id), _STEERING_TTL_S)
 
 
 def _redis_get_owner_sync(session_id: str) -> str | None:
@@ -419,10 +463,35 @@ def _redis_backfill_owner_sync(session_id: str, user_id: str) -> None:
     get_redis_client().set(_owner_key(session_id), user_id, ex=_STEERING_TTL_S, xx=True)
 
 
-def _redis_cleanup_sync(session_id: str) -> None:
+# Lua 脚本保证「移除本 run 的持有 → 判断是否还有其它 run → 删除」在 Redis
+# 端原子执行：非原子的 SREM/SCARD/DEL 序列之间，另一个 worker 上的并发 run
+# 可能刚完成注册，会把它正在使用的队列误删。
+_RELEASE_RUN_SCRIPT: Final[str] = """
+redis.call('SREM', KEYS[1], ARGV[1])
+if redis.call('SCARD', KEYS[1]) == 0 then
+    redis.call('DEL', KEYS[1], KEYS[2], KEYS[3])
+    return 1
+end
+return 0
+"""
+
+
+def _redis_cleanup_sync(session_id: str, run_id: str | None = None) -> None:
     from services.infra.redis_client import get_redis_client
 
-    get_redis_client().delete(_owner_key(session_id), _msgs_key(session_id))
+    client = get_redis_client()
+    if not run_id:
+        # 旧语义：无条件删除（测试/运维路径）。
+        client.delete(_owner_key(session_id), _msgs_key(session_id), _runs_key(session_id))
+        return
+    client.eval(
+        _RELEASE_RUN_SCRIPT,
+        3,
+        _runs_key(session_id),
+        _owner_key(session_id),
+        _msgs_key(session_id),
+        run_id,
+    )
 
 
 # Global in-memory queue manager (fallback for single-worker / no-Redis dev).
@@ -440,12 +509,19 @@ async def get_steering_queue_async(session_id: str) -> Any:
 async def create_steering_queue_async(
     session_id: str,
     owner_user_id: str | None,
+    run_id: str | None = None,
 ) -> Any:
-    """Create/get queue and bind ownership when available."""
+    """Create/get queue and bind ownership when available.
+
+    run_id 标识一次 stream run 对队列的持有：同一 session 的并发 run 共享
+    队列，cleanup 传入相同 run_id 时只释放自己的持有。
+    """
     if await _redis_available():
-        await asyncio.to_thread(_redis_create_sync, session_id, owner_user_id)
+        await asyncio.to_thread(_redis_create_sync, session_id, owner_user_id, run_id)
         return RedisSteeringQueue(session_id)
-    return await _queue_manager.get_queue(session_id, owner_user_id=owner_user_id)
+    return await _queue_manager.get_queue(
+        session_id, owner_user_id=owner_user_id, run_id=run_id
+    )
 
 
 async def get_steering_queue_for_user_async(session_id: str, user_id: str) -> Any:
@@ -464,9 +540,13 @@ async def get_steering_queue_for_user_async(session_id: str, user_id: str) -> An
     return await _queue_manager.get_queue_for_user(session_id, user_id)
 
 
-async def cleanup_steering_queue_async(session_id: str) -> None:
-    """Remove steering queue for a session (async version)."""
+async def cleanup_steering_queue_async(session_id: str, run_id: str | None = None) -> None:
+    """Release a run's hold on the steering queue (async version).
+
+    带 run_id 时只释放该 run 的持有，最后一个持有者退出才真正删除；
+    不带 run_id 保持旧语义，无条件删除。
+    """
     if await _redis_available():
-        await asyncio.to_thread(_redis_cleanup_sync, session_id)
+        await asyncio.to_thread(_redis_cleanup_sync, session_id, run_id)
         return
-    await _queue_manager.cleanup(session_id)
+    await _queue_manager.cleanup(session_id, run_id=run_id)

--- a/apps/server/agent/core/steering.py
+++ b/apps/server/agent/core/steering.py
@@ -439,15 +439,34 @@ def _redis_create_sync(
 ) -> None:
     from services.infra.redis_client import get_redis_client
 
-    # The session owner starts the stream they own (session_id is their
-    # chat_session.id), so binding the owner here is authoritative.
+    # 注册必须和释放（_RELEASE_RUN_SCRIPT）互相原子：若拆成 SET owner 与
+    # SADD runs 两次 round-trip，另一个 worker 上并发结束的 run 会整段插在
+    # 中间执行释放（SREM → SCARD==0 → DEL owner/msgs/runs），结果本 run 注册
+    # 完成后 runs={本 run} 而 owner 已被删——本 run 剩余时间里所有
+    # POST /agent/steer 都 404（_add_sync/_pop_all_sync 只 EXPIRE，不会重建
+    # owner 键），并且已排队未消费的 steering 消息随 msgs 键一起丢失。
+    # MULTI/EXEC 让释放脚本只能看到「注册前」或「注册后」两种状态。
     client = get_redis_client()
-    client.set(_owner_key(session_id), owner_user_id or "", ex=_STEERING_TTL_S)
+    pipe = client.pipeline(transaction=True)
     if run_id:
         # 记录持有队列的 run：同一 session 的并发 run 共享 owner/msgs 键，
         # cleanup 只在最后一个 run 释放时才真正删除（见 _RELEASE_RUN_SCRIPT）。
-        client.sadd(_runs_key(session_id), run_id)
-        client.expire(_runs_key(session_id), _STEERING_TTL_S)
+        # 先写 runs 再写 owner：即使将来被拆回多条命令，也不会留下
+        # 「owner 已写、runs 未写」这个最坏顺序。
+        pipe.sadd(_runs_key(session_id), run_id)
+        pipe.expire(_runs_key(session_id), _STEERING_TTL_S)
+    if owner_user_id:
+        # The session owner starts the stream they own (session_id is their
+        # chat_session.id), so binding the owner here is authoritative.
+        pipe.set(_owner_key(session_id), owner_user_id, ex=_STEERING_TTL_S)
+    else:
+        # 调用方不知道 owner 时（get_steering_queue_async）只在键缺失时占位：
+        # nx=True 保证不会把已绑定的真实 owner 降级成空串，否则
+        # get_steering_queue_for_user_async 会跳过 owner 校验并把队列
+        # backfill 给任意请求者。
+        pipe.set(_owner_key(session_id), "", ex=_STEERING_TTL_S, nx=True)
+        pipe.expire(_owner_key(session_id), _STEERING_TTL_S)
+    pipe.execute()
 
 
 def _redis_get_owner_sync(session_id: str) -> str | None:
@@ -499,7 +518,12 @@ _queue_manager = SteeringQueueManager()
 
 
 async def get_steering_queue_async(session_id: str) -> Any:
-    """Get or create steering queue for a session (async version)."""
+    """Get or create steering queue for a session (async version).
+
+    不绑定 owner：仅在 owner 键缺失时占位，已绑定的 owner 保持不变。生产入口
+    请用 create_steering_queue_async（写入真实 owner）或
+    get_steering_queue_for_user_async（校验 owner）。
+    """
     if await _redis_available():
         await asyncio.to_thread(_redis_create_sync, session_id, None)
         return RedisSteeringQueue(session_id)
@@ -544,7 +568,8 @@ async def cleanup_steering_queue_async(session_id: str, run_id: str | None = Non
     """Release a run's hold on the steering queue (async version).
 
     带 run_id 时只释放该 run 的持有，最后一个持有者退出才真正删除；
-    不带 run_id 保持旧语义，无条件删除。
+    不带 run_id 保持旧语义，无条件删除——会连带删掉其它并发 run 正在使用的
+    队列，因此仅用于测试/运维清理，生产路径（service.py）始终传 run_id。
     """
     if await _redis_available():
         await asyncio.to_thread(_redis_cleanup_sync, session_id, run_id)

--- a/apps/server/agent/core/stream_processor.py
+++ b/apps/server/agent/core/stream_processor.py
@@ -46,6 +46,44 @@ ESCAPED_FILE_PATTERNS = [
     r'&lt;file&gt;',       # HTML 转义
 ]
 
+# 代码块围栏定界符（与 ESCAPED_FILE_PATTERNS 中代码块模式的定界一致）
+FENCE = "```"
+
+# 标记判定结果：真实标记 / 代码上下文中的字面量 / 需要更多 chunk 才能判定
+_MARKER_REAL = "real"
+_MARKER_PROTECTED = "protected"
+_MARKER_AMBIGUOUS = "ambiguous"
+
+
+def _classify_marker(
+    buffer: str,
+    match: "re.Match[str]",
+    prev_char: str,
+    fence_open: bool,
+    at_eof: bool,
+) -> str:
+    """判定 buffer 中一个 <file>/</file> 命中是真实标记还是代码上下文中的字面量。
+
+    与 ESCAPED_FILE_PATTERNS 共用同一套语义：紧邻反引号的行内代码、闭合 ```
+    围栏内的命中都是字面量。流式场景下反引号/围栏可能尚未闭合，此时返回
+    ambiguous 表示需等待后续 chunk；at_eof 时不会再有后续内容，按闭合永远
+    不会发生处理（即视为真实标记）。
+
+    prev_char / fence_open 提供 buffer 之前已被消费内容的上下文（紧邻的
+    前一个字符、``` 围栏的开合奇偶性），使判定不受 flush 边界影响。
+    """
+    start, end = match.start(), match.end()
+    if fence_open:
+        if FENCE in buffer[end:]:
+            return _MARKER_PROTECTED
+        return _MARKER_REAL if at_eof else _MARKER_AMBIGUOUS
+    before = buffer[start - 1] if start > 0 else prev_char
+    if before == "`":
+        if end < len(buffer):
+            return _MARKER_PROTECTED if buffer[end] == "`" else _MARKER_REAL
+        return _MARKER_REAL if at_eof else _MARKER_AMBIGUOUS
+    return _MARKER_REAL
+
 # Buffer size limit (1MB)
 BUFFER_MAX_SIZE = 1024 * 1024
 
@@ -170,6 +208,11 @@ class StreamProcessor:
     temp_buffer: str = ""  # Buffer for potential partial markers
     history_buffer: str = ""  # Content for LLM history
 
+    # 跨 flush 的标记判定上下文：temp_buffer 之前最后一个已消费字符（判断
+    # 行内代码的前置反引号）、已消费内容中 ``` 围栏的开合奇偶性
+    prev_char: str = ""
+    fence_open: bool = False
+
     def reset(self) -> None:
         """Reset processor to idle state."""
         self.state = StreamState.IDLE
@@ -177,6 +220,8 @@ class StreamProcessor:
         self.content_buffer = ""
         self.temp_buffer = ""
         self.history_buffer = ""
+        self.prev_char = ""
+        self.fence_open = False
 
     def start_file_write(self, file_id: str) -> None:
         """
@@ -190,6 +235,8 @@ class StreamProcessor:
         self.content_buffer = ""
         self.temp_buffer = ""
         self.history_buffer = ""
+        self.prev_char = ""
+        self.fence_open = False
 
         log_with_context(
             logger,
@@ -236,7 +283,9 @@ class StreamProcessor:
         # Match against the accumulated buffer with the fault-tolerant regex (not
         # the exact literal), so a case/whitespace variant marker split across
         # chunks (e.g. "<FI" + "LE>") is still detected once reassembled.
-        start_match = FILE_START_PATTERN.search(self.temp_buffer)
+        # 叙述中处于行内代码/``` 围栏内的 <file> 是字面量，跳过继续向后找；
+        # 尚无法判定（反引号/围栏未闭合）时继续缓冲等待后续 chunk。
+        start_match = self._find_real_start_marker()
         if start_match:
             # Found start marker - split content around the matched span
             before_marker = self.temp_buffer[: start_match.start()]
@@ -245,6 +294,8 @@ class StreamProcessor:
             # Transition to writing state
             self.state = StreamState.WRITING
             self.temp_buffer = after_marker
+            self.prev_char = ""
+            self.fence_open = False
 
             log_with_context(
                 logger,
@@ -284,36 +335,122 @@ class StreamProcessor:
         # Keep buffering
         return StreamResult()
 
+    def _find_real_start_marker(self, at_eof: bool = False) -> "re.Match[str] | None":
+        """在 WAITING_START 缓冲中找第一个真实的 <file> 开始标记。
+
+        WAITING_START 不 flush，缓冲从头累积，围栏/反引号上下文直接在
+        缓冲内计算。命中为字面量则跳过；命中歧义（需等待后续 chunk）则
+        返回 None 继续缓冲。
+
+        at_eof 时不会再有后续 chunk：歧义按「闭合永不发生」判为真实标记；
+        若首轮仍无命中，再放宽 ``` 围栏保护兜底扫一遍（见
+        _search_start_marker）。
+        """
+        match = self._search_start_marker(at_eof=at_eof, ignore_fence=False)
+        if match is None and at_eof:
+            return self._search_start_marker(at_eof=True, ignore_fence=True)
+        return match
+
+    def _search_start_marker(
+        self, at_eof: bool, ignore_fence: bool
+    ) -> "re.Match[str] | None":
+        """扫描 WAITING_START 缓冲中的 <file> 候选。
+
+        ignore_fence 是流结束时的兜底：模型常照抄提示词范例，把整块
+        <file>…</file> 包在 ``` 围栏里输出，此时围栏保护会让开始标记永远
+        判为字面量。create_file 已产出空文件、缓冲本就应当是文件正文，把带
+        标记的整章正文倒进聊天严格劣于当作正文写入。为避免把纯格式说明写进
+        文件，兜底只认围栏内成对出现的 <file>…</file>；行内代码保护不放宽。
+        """
+        buffer = self.temp_buffer
+        pos = 0
+        fence_open = False
+        counted = 0
+        while True:
+            match = FILE_START_PATTERN.search(buffer, pos)
+            if match is None:
+                return None
+            if ignore_fence:
+                if FILE_END_PATTERN.search(buffer, match.end()) is None:
+                    return None
+            else:
+                if buffer.count(FENCE, counted, match.start()) % 2 == 1:
+                    fence_open = not fence_open
+                counted = match.start()
+            verdict = _classify_marker(buffer, match, "", fence_open, at_eof=at_eof)
+            if verdict == _MARKER_REAL:
+                return match
+            if verdict == _MARKER_AMBIGUOUS:
+                return None
+            pos = match.end()
+
     def _process_writing(self, content: str) -> StreamResult:
         """Process content while writing file."""
         self.temp_buffer += content
+        return self._scan_writing_buffer(at_eof=False)
 
-        # 检测嵌套的 <file> 标记（异常情况），容忍大小写/空白变体
-        # 这可能是 LLM 幻觉或用户在内容中讨论 XML 标签
-        if FILE_START_PATTERN.search(self.temp_buffer):
-            nested_count = len(FILE_START_PATTERN.findall(self.temp_buffer))
+    def _scan_writing_buffer(self, at_eof: bool) -> StreamResult:
+        """扫描 WRITING 缓冲：跳过代码上下文中的字面量标记，转义真实的
+        嵌套 <file>，在真实 </file> 处完成文件。"""
+        buffer = self.temp_buffer
+        pos = 0
+        fence_open = self.fence_open
+        counted = 0
+        while True:
+            start_match = FILE_START_PATTERN.search(buffer, pos)
+            end_match = FILE_END_PATTERN.search(buffer, pos)
+            if start_match is None and end_match is None:
+                break
+            if end_match is None or (
+                start_match is not None and start_match.start() < end_match.start()
+            ):
+                kind, match = "start", start_match
+            else:
+                kind, match = "end", end_match
+            if buffer.count(FENCE, counted, match.start()) % 2 == 1:
+                fence_open = not fence_open
+            counted = match.start()
+            verdict = _classify_marker(
+                buffer, match, self.prev_char, fence_open, at_eof
+            )
+            if verdict == _MARKER_PROTECTED:
+                pos = match.end()
+                continue
+            if verdict == _MARKER_AMBIGUOUS:
+                # 反引号/围栏是否闭合尚无法判定：flush 命中点之前的内容，
+                # 其余留在缓冲等待后续 chunk。挂起的尾部同样受总量上限
+                # 约束，超限时整体走溢出强制完成，防止缓冲无界增长。
+                self.temp_buffer = buffer
+                if len(self.content_buffer) + len(buffer) > BUFFER_MAX_SIZE:
+                    return self._flush_file_content(len(buffer))
+                return self._flush_file_content(match.start())
+            if kind == "end":
+                self.temp_buffer = buffer
+                return self._handle_end_marker(match)
+            # 真实的嵌套 <file> 标记（异常情况），容忍大小写/空白变体
+            # 这可能是 LLM 幻觉或用户在内容中讨论 XML 标签
             log_with_context(
                 logger,
                 30,  # WARNING
-                "Detected nested <file> markers in content, escaping them",
-                count=nested_count,
+                "Detected nested <file> marker in content, escaping it",
                 project_id=self.project_id,
                 user_id=self.user_id,
                 file_id=self.file_id,
             )
-            # 转义所有嵌套的开始标记变体
-            self.temp_buffer = FILE_START_PATTERN.sub('&lt;file&gt;', self.temp_buffer)
+            buffer = buffer[: match.start()] + '&lt;file&gt;' + buffer[match.end():]
+            pos = match.start() + len('&lt;file&gt;')
+            counted = pos
 
-        end_match = FILE_END_PATTERN.search(self.temp_buffer)
-        if end_match:
-            return self._handle_end_marker(end_match)
+        self.temp_buffer = buffer
+        if at_eof:
+            return StreamResult()
 
         # No end marker yet - check if we have safe content to send. Reserve a
         # full marker-variant's worth of trailing chars (not just len('</file>'))
         # so a split whitespace variant like "< /file >" is never flushed before
         # it can be reassembled and matched.
-        if len(self.temp_buffer) > MAX_MARKER_LEN:
-            return self._send_safe_content(MAX_MARKER_LEN)
+        if len(buffer) > MAX_MARKER_LEN:
+            return self._flush_file_content(len(buffer) - MAX_MARKER_LEN)
 
         # Buffer too small, just accumulate
         return StreamResult()
@@ -356,9 +493,23 @@ class StreamProcessor:
             conversation_content_after_file=after_marker if after_marker else "",
         )
 
-    def _send_safe_content(self, reserve: int) -> StreamResult:
+    def _adjust_cut_for_backtick_run(self, cut: int) -> int:
+        """把切分点左移出反引号连续段，避免 ``` 围栏被 flush 边界拆散后
+        无法再按整体统计开合奇偶性。"""
+        while (
+            0 < cut < len(self.temp_buffer)
+            and self.temp_buffer[cut] == "`"
+            and self.temp_buffer[cut - 1] == "`"
+        ):
+            cut -= 1
+        return cut
+
+    def _flush_file_content(self, cut: int) -> StreamResult:
         """Send content that's safe (not potentially part of end marker)."""
-        safe_content = self.temp_buffer[:-reserve]
+        cut = self._adjust_cut_for_backtick_run(cut)
+        safe_content = self.temp_buffer[:cut]
+        if not safe_content:
+            return StreamResult()
 
         # Check content_buffer size limit
         new_content_size = len(self.content_buffer) + len(safe_content)
@@ -379,6 +530,9 @@ class StreamProcessor:
             content_length = len(final_content)
             file_id = self.file_id
 
+            if safe_content.count(FENCE) % 2 == 1:
+                self.fence_open = not self.fence_open
+            self.prev_char = safe_content[-1]
             self._begin_draining()
 
             return StreamResult(
@@ -393,7 +547,10 @@ class StreamProcessor:
         # Add to buffers and keep remaining in temp
         self.content_buffer += safe_content
         self.history_buffer += safe_content
-        self.temp_buffer = self.temp_buffer[-reserve:]
+        self.temp_buffer = self.temp_buffer[cut:]
+        if safe_content.count(FENCE) % 2 == 1:
+            self.fence_open = not self.fence_open
+        self.prev_char = safe_content[-1]
 
         return StreamResult(
             file_content=safe_content,
@@ -411,6 +568,17 @@ class StreamProcessor:
         self.history_buffer = ""
         self.temp_buffer = ""
 
+    def _discard_drained(self, cut: int) -> None:
+        """丢弃 drain 缓冲的前段，并维护标记判定所需的跨段上下文。"""
+        cut = self._adjust_cut_for_backtick_run(cut)
+        dropped = self.temp_buffer[:cut]
+        if not dropped:
+            return
+        if dropped.count(FENCE) % 2 == 1:
+            self.fence_open = not self.fence_open
+        self.prev_char = dropped[-1]
+        self.temp_buffer = self.temp_buffer[cut:]
+
     def _process_draining(self, content: str) -> StreamResult:
         """Swallow the overflow tail of a force-completed file until </file>.
 
@@ -419,15 +587,38 @@ class StreamProcessor:
         leaks into the chat transcript.
         """
         self.temp_buffer += content
-        end_match = FILE_END_PATTERN.search(self.temp_buffer)
-        if end_match:
-            after_marker = self.temp_buffer[end_match.end():]
+        buffer = self.temp_buffer
+        pos = 0
+        fence_open = self.fence_open
+        counted = 0
+        while True:
+            end_match = FILE_END_PATTERN.search(buffer, pos)
+            if end_match is None:
+                break
+            if buffer.count(FENCE, counted, end_match.start()) % 2 == 1:
+                fence_open = not fence_open
+            counted = end_match.start()
+            verdict = _classify_marker(
+                buffer, end_match, self.prev_char, fence_open, at_eof=False
+            )
+            if verdict == _MARKER_PROTECTED:
+                pos = end_match.end()
+                continue
+            if verdict == _MARKER_AMBIGUOUS:
+                # 保留待判定的尾部，前段照常丢弃；歧义迟迟不消除时按未闭合
+                # 围栏内容处理（连同候选一起丢弃），保证 drain 缓冲有界
+                if len(buffer) > BUFFER_MAX_SIZE:
+                    self._discard_drained(len(buffer) - MAX_MARKER_LEN)
+                else:
+                    self._discard_drained(end_match.start())
+                return StreamResult()
+            after_marker = buffer[end_match.end():]
             self.reset()
             return StreamResult(conversation_content=after_marker or "")
 
         # Bound the drain buffer — only the tail is needed to spot a split </file>.
         if len(self.temp_buffer) > MAX_MARKER_LEN:
-            self.temp_buffer = self.temp_buffer[-MAX_MARKER_LEN:]
+            self._discard_drained(len(self.temp_buffer) - MAX_MARKER_LEN)
         return StreamResult()
 
     def finalize_on_stream_end(self) -> StreamResult:
@@ -448,6 +639,24 @@ class StreamProcessor:
             return StreamResult()
 
         if self.state == StreamState.WAITING_START:
+            # 流结束后悬置的反引号/围栏不会再闭合：先按 at_eof 语义复扫开始
+            # 标记，否则叙述里一个未闭合的 ``` 就会让整章正文（连同 <file>
+            # 原始标记）当作对话倒进聊天、文件留空。命中后转入 WRITING 并复用
+            # 下方 WRITING 分支（含 control-marker 污染守卫）完成文件。
+            start_match = self._find_real_start_marker(at_eof=True)
+            if start_match is not None:
+                before_marker = self.temp_buffer[: start_match.start()]
+                self.state = StreamState.WRITING
+                self.temp_buffer = self.temp_buffer[start_match.end():]
+                self.prev_char = ""
+                self.fence_open = False
+                result = self.finalize_on_stream_end()
+                if before_marker:
+                    result.conversation_content = (
+                        before_marker + result.conversation_content
+                    )
+                return result
+
             buffered = self.temp_buffer
             log_with_context(
                 logger,
@@ -462,6 +671,12 @@ class StreamProcessor:
             return StreamResult(conversation_content=buffered)
 
         if self.state == StreamState.WRITING:
+            # 流结束后悬置的反引号/围栏不会再闭合：先按 at_eof 语义重扫缓冲，
+            # 此前因歧义挂起的 </file> 到这里可确认为真实结束标记
+            scanned = self._scan_writing_buffer(at_eof=True)
+            if scanned.file_complete:
+                return scanned
+
             trailing = self.temp_buffer
             if trailing:
                 self.content_buffer += trailing

--- a/apps/server/agent/graph/writing_graph.py
+++ b/apps/server/agent/graph/writing_graph.py
@@ -33,6 +33,57 @@ logger = get_logger(__name__)
 # write). Bounded so a model that keeps failing cannot loop indefinitely.
 MAX_FILE_CORRECTION_ATTEMPTS = 2
 
+# pending-empty-file 标记的落库核验结果
+_PENDING_BODY_EMPTY = "empty"
+_PENDING_BODY_WRITTEN = "written"
+_PENDING_BODY_GONE = "gone"
+_PENDING_BODY_UNVERIFIABLE = "unverifiable"
+
+
+def _probe_pending_file_body(file_id: str) -> str:
+    """核验 pending-empty-file 标记指向的文件正文当前是否真的为空。
+
+    标记由 create_file(不带 content) 置上，只有 <file>…</file> 流式写入完成
+    （或流结束）时才会清除；edit_file 把正文写进去并不会清除它。所以"标记仍在"
+    只说明模型没走流式写入协议，不代表正文为空——必须落库核验，否则
+    create_file(空) + edit_file(op=append) 这条常走路径会被误判成空文件。
+
+    核验不了时（无 file_id / 无可用 session / 查询失败）返回 unverifiable，
+    由调用方保留原来的纠偏兜底。这里用列级查询，绕开 ORM 身份映射里可能陈旧的
+    实例，直接读数据库当前值。
+    """
+    if not file_id:
+        return _PENDING_BODY_UNVERIFIABLE
+
+    try:
+        from sqlmodel import select
+
+        from models import File
+
+        session = ToolContext.get_session()
+        row = session.exec(
+            select(File.content, File.is_deleted).where(File.id == file_id)
+        ).first()
+    except Exception as e:
+        logger.debug(f"Pending empty-file verification failed: {e}")
+        return _PENDING_BODY_UNVERIFIABLE
+
+    if row is None:
+        return _PENDING_BODY_GONE
+    content, is_deleted = row[0], row[1]
+    if is_deleted:
+        return _PENDING_BODY_GONE
+    return _PENDING_BODY_EMPTY if not str(content or "").strip() else _PENDING_BODY_WRITTEN
+
+# 追加轮提示：openai-agents 不支持向进行中的 run 注入消息，运行期间到达的
+# steering 只能在 run 结束后补一轮 writer 才能在本次请求内生效；引导内容
+# 本身已作为用户消息追加进会话历史，这里只引导模型去看它。
+STEERING_FOLLOWUP_CONTEXT = (
+    "[系统提醒] 用户在生成过程中发来了新的引导消息（见对话历史末尾的用户消息）。"
+    "请在已完成工作的基础上按用户最新引导继续调整或补充；"
+    "如果引导无需改动已完成内容，请简要回应说明。"
+)
+
 
 def _extract_review_payload(agent_content: str) -> str:
     """
@@ -236,6 +287,52 @@ async def run_writing_workflow_streaming(
         "writer": "内容创作者",
         "quality_reviewer": "质量审稿人",
     }
+
+    async def _drain_boundary_steering() -> list[dict[str, str]]:
+        """Agent 边界消费 steering 队列。
+
+        覆盖 run 内没有工具边界可消费（纯文本生成）、或落在最后一个 agent
+        运行期间的消息；不消费则它们只会在流结束时被持久化，无法影响本次
+        请求的生成。
+        """
+        if get_steering_messages is None:
+            return []
+        try:
+            raw_msgs = await get_steering_messages()
+        except Exception as exc:
+            log_with_context(
+                logger,
+                40,  # ERROR
+                "Failed to retrieve steering messages at agent boundary",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            return []
+        drained: list[dict[str, str]] = []
+        for msg in raw_msgs or []:
+            if not isinstance(msg, dict):
+                continue
+            content = str(msg.get("content") or "")
+            if content:
+                drained.append({"id": str(msg.get("id") or ""), "content": content})
+        return drained
+
+    async def _absorb_boundary_steering(
+        boundary_msgs: list[dict[str, str]],
+    ) -> AsyncIterator[StreamEvent]:
+        """把边界消费的 steering 追加进会话消息，并向前端发确认事件。"""
+        if not boundary_msgs:
+            return
+        state["messages"] = list(state.get("messages") or []) + [
+            {"role": "user", "content": msg["content"]} for msg in boundary_msgs
+        ]
+        from agent.core.events import steering_received_event
+
+        for msg in boundary_msgs:
+            yield steering_received_event(
+                message_id=msg["id"],
+                preview=msg["content"][:50],
+            )
 
     iteration = 0
     current_agent_type: str | None = None
@@ -484,10 +581,25 @@ async def run_writing_workflow_streaming(
             invalid_handoff_stopped = False
             writer_used_write_tools = False
             writer_emitted_file_markers = False
+            agent_message_started = False
+            mid_run_steering_seen = False
+            agent_run_errored = False
 
             async for event in run_streaming_agent(
                 modified_state, current_agent_type, get_steering_messages=get_steering_messages
             ):
+                if event.type == StreamEventType.MESSAGE_START:
+                    agent_message_started = True
+                elif event.type == StreamEventType.ERROR:
+                    agent_run_errored = True
+                elif (
+                    getattr(event.type, "value", "") == "steering_received"
+                    and agent_message_started
+                ):
+                    # MESSAGE_START 之前的 steering 已注入本次 run 的输入；
+                    # 之后的是 runner 在工具边界消费、本次 run 无法生效的干预。
+                    mid_run_steering_seen = True
+
                 # Track text content for auto-review threshold
                 if event.type == StreamEventType.TEXT:
                     text = event.data.get("text", "")
@@ -587,6 +699,10 @@ async def run_writing_workflow_streaming(
             # narration from being persisted as the file's content), re-run the
             # writer and explicitly tell it to finish the file. Bounded by
             # MAX_FILE_CORRECTION_ATTEMPTS to avoid loops.
+            #
+            # 触发前必须落库核验（_probe_pending_file_body）：标记只表示"没走
+            # <file>…</file> 流式写入"，模型改用 edit_file(op=append) 写完正文时
+            # 标记依然留着，此时按"正文仍为空"重跑会让正文被追加两遍。
             if (
                 not clarification_stopped
                 and not invalid_handoff_stopped
@@ -598,30 +714,46 @@ async def run_writing_workflow_streaming(
                 pending = ToolContext.get_pending_empty_file() or {}
                 pending_title = str(pending.get("title") or "未命名")
                 pending_file_id = str(pending.get("file_id") or pending.get("id") or "")
-                file_correction_attempts += 1
-                # Clear the guard now: the explicit instruction below replaces its
-                # blocking role, and leaving it set would re-trigger this branch
-                # even after edit_file fills the file (edit_file does not clear it).
-                ToolContext.clear_pending_empty_file()
-                log_with_context(
-                    logger,
-                    30,  # WARNING
-                    "Empty file detected after agent turn; re-running writer to complete it",
-                    file_id=pending_file_id,
-                    title=pending_title,
-                    attempt=file_correction_attempts,
-                )
-                id_hint = f"(id={pending_file_id})" if pending_file_id else ""
-                handoff_context = (
-                    f"[系统提醒] 你创建的文件《{pending_title}》{id_hint} 正文仍为空——"
-                    "上一轮没有用 <file>…</file> 完成流式写入（很可能漏了结尾的 </file>）。"
-                    "请立即调用 edit_file（id="
-                    f"{pending_file_id or '<该文件id>'}，op=append）把完整正文写入该文件；"
-                    "不要重复创建文件，也不要只在对话里复述正文。"
-                )
-                previous_agent = current_agent_type
-                current_agent_type = "writer"
-                continue
+                body_state = _probe_pending_file_body(pending_file_id)
+                if body_state in (_PENDING_BODY_WRITTEN, _PENDING_BODY_GONE):
+                    # 正文已经写入（或文件已被删除）：没有可补的内容，只需把没人
+                    # 清理的标记清掉，避免它继续阻塞 create_file / parallel_execute。
+                    ToolContext.clear_pending_empty_file()
+                    log_with_context(
+                        logger,
+                        20,  # INFO
+                        "Pending empty-file guard cleared without correction",
+                        file_id=pending_file_id,
+                        title=pending_title,
+                        body_state=body_state,
+                    )
+                else:
+                    file_correction_attempts += 1
+                    # Clear the guard now: the explicit instruction below replaces its
+                    # blocking role, and leaving it set would re-trigger this branch
+                    # even after edit_file fills the file (edit_file does not clear it).
+                    ToolContext.clear_pending_empty_file()
+                    log_with_context(
+                        logger,
+                        30,  # WARNING
+                        "Empty file detected after agent turn; re-running writer to complete it",
+                        file_id=pending_file_id,
+                        title=pending_title,
+                        attempt=file_correction_attempts,
+                        body_state=body_state,
+                    )
+                    id_hint = f"(id={pending_file_id})" if pending_file_id else ""
+                    handoff_context = (
+                        f"[系统提醒] 你创建的文件《{pending_title}》{id_hint} 正文仍为空——"
+                        "上一轮没有用 <file>…</file> 完成流式写入（很可能漏了结尾的 </file>）。"
+                        "请立即调用 edit_file（id="
+                        f"{pending_file_id or '<该文件id>'}，op=append）把完整正文写入该文件；"
+                        "不要重复创建文件，也不要只在对话里复述正文。"
+                        "若该文件已有部分正文，只补齐缺失的部分，不要重复写入已有段落。"
+                    )
+                    previous_agent = current_agent_type
+                    current_agent_type = "writer"
+                    continue
 
             # Structured clarification stop is canonical and must block planned/auto handoff.
             if clarification_stopped:
@@ -759,6 +891,32 @@ async def run_writing_workflow_streaming(
                     f"{base_context}\n\n"
                     f"[待审查内容]\n{review_payload}"
                 ).strip()
+
+            # 本轮 run 期间到达的 steering：SDK run 中途无法注入，只有当没有
+            # 已计划的下一个 agent（否则该 agent 的起始注入/会话历史会带上
+            # 这些消息）时，追加一轮 writer 让干预在本次请求内生效。消费过的
+            # 消息不会重复触发；追加轮同样计入 max_iterations，不会无限循环。
+            if (
+                not has_pending_handoff
+                and not agent_run_errored
+                and iteration < max_iterations
+            ):
+                boundary_steering = await _drain_boundary_steering()
+                if mid_run_steering_seen or boundary_steering:
+                    async for steering_ack in _absorb_boundary_steering(boundary_steering):
+                        yield steering_ack
+                    log_with_context(
+                        logger,
+                        20,
+                        "Steering arrived during agent run; scheduling writer follow-up",
+                        agent_type=current_agent_type,
+                        mid_run_consumed=mid_run_steering_seen,
+                        boundary_consumed=len(boundary_steering),
+                    )
+                    handoff_context = STEERING_FOLLOWUP_CONTEXT
+                    previous_agent = current_agent_type
+                    current_agent_type = "writer"
+                    continue
 
             # 检测任务完成。
             # - 显式 handoff 优先级最高（继续协作，不触发 stop/complete）。

--- a/apps/server/agent/openai_agents/runner.py
+++ b/apps/server/agent/openai_agents/runner.py
@@ -270,6 +270,42 @@ async def _inject_initial_steering(
         )
 
 
+async def _consume_boundary_steering(
+    collected: list[str],
+    get_steering_messages: Callable[[], Any] | None,
+) -> AsyncIterator[StreamEvent]:
+    """Consume steering that arrived while the SDK run is executing.
+
+    openai-agents 不支持向进行中的 run 注入消息，工具输出边界只做消费与
+    前端确认；内容暂存 collected，run 结束后写回 state.messages，由 graph
+    决定是否追加一轮 writer 让引导在本次请求内生效。
+    """
+    if get_steering_messages is None:
+        return
+    try:
+        steering_msgs = await get_steering_messages()
+    except Exception as exc:
+        log_with_context(
+            logger,
+            40,  # ERROR
+            "Failed to retrieve steering messages at tool boundary",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return
+    for msg in steering_msgs or []:
+        content = str(msg.get("content") or "") if isinstance(msg, dict) else ""
+        if not content:
+            continue
+        collected.append(content)
+        from agent.core.events import steering_received_event
+
+        yield steering_received_event(
+            message_id=str(msg.get("id") or "") if isinstance(msg, dict) else "",
+            preview=content[:50],
+        )
+
+
 async def _pump_sdk_events(result: Any, run_queue: asyncio.Queue[tuple[str, Any]]) -> None:
     """Forward SDK stream events onto the shared run queue, tagged by kind.
 
@@ -307,6 +343,7 @@ async def run_openai_agents_streaming_agent(
     tool_uses: list[dict[str, Any]] = []
     tool_inputs_by_call_id: dict[str, dict[str, Any]] = {}
     tool_names_by_call_id: dict[str, str] = {}
+    mid_run_steering: list[str] = []
     artifact_refs_accumulated: list[str] = []
     handoff_event_data: dict[str, Any] | None = None
     clarification_event_data: dict[str, Any] | None = None
@@ -525,6 +562,13 @@ async def run_openai_agents_streaming_agent(
                             "details": normalize_str_list(result_data.get("details")),
                         }
                         result.cancel(mode="after_turn")
+
+                    # 工具输出边界是 run 内唯一能消费 steering 的时机（SDK 事件
+                    # 消费循环的其余位置都在等模型流式输出）。
+                    async for steering_event in _consume_boundary_steering(
+                        mid_run_steering, get_steering_messages
+                    ):
+                        yield steering_event
         except MaxTurnsExceeded:
             yield StreamEvent(
                 type=StreamEventType.ITERATION_EXHAUSTED,
@@ -593,3 +637,9 @@ async def run_openai_agents_streaming_agent(
             thinking_text="".join(thinking_text_parts),
             tool_uses=tool_uses,
         )
+        if mid_run_steering:
+            # 工具边界消费的 steering 作为用户消息进入后续迭代的输入
+            # （本次 SDK run 已经无法注入）。
+            state["messages"] = list(state.get("messages") or []) + [
+                {"role": "user", "content": content} for content in mid_run_steering
+            ]

--- a/apps/server/agent/service.py
+++ b/apps/server/agent/service.py
@@ -92,7 +92,9 @@ class AgentService:
         )
 
     @staticmethod
-    def _schedule_background_cleanup(coro: Any, *, description: str, session_id: str | None) -> None:
+    def _schedule_background_cleanup(
+        coro: Any, *, description: str, session_id: str | None
+    ) -> asyncio.Task:
         """Run async cleanup out of band when generator cancellation makes awaiting risky."""
         task = asyncio.create_task(coro)
 
@@ -111,6 +113,7 @@ class AgentService:
                 )
 
         task.add_done_callback(_log_task_result)
+        return task
 
     @staticmethod
     def _should_offload_session_work(session: Session) -> bool:
@@ -180,15 +183,24 @@ class AgentService:
                     ).all()
 
                     changed = False
-                    if not candidate.is_active:
-                        candidate.is_active = True
-                        changed = True
-
+                    deactivated = False
                     for stale in other_actives:
                         if stale.is_active:
                             stale.is_active = False
                             session.add(stale)
                             changed = True
+                            deactivated = True
+
+                    if not candidate.is_active:
+                        # 部分唯一索引 (user_id, project_id) WHERE is_active=true
+                        # 非延迟约束，而 SQLAlchemy 对同一 mapper 的 UPDATE 按主键
+                        # 排序下发；必须先把旧活跃会话的去激活刷到数据库，再激活
+                        # candidate，否则 candidate 主键较小时会瞬时出现两行
+                        # active 触发 IntegrityError。
+                        if deactivated:
+                            session.flush()
+                        candidate.is_active = True
+                        changed = True
 
                     candidate.updated_at = utcnow()
                     session.add(candidate)
@@ -453,8 +465,13 @@ class AgentService:
         else:
             session_id = requested_session_id or str(uuid.uuid4())
 
-        # Initialize steering queue for this session
-        steering_queue = await create_steering_queue_async(session_id, user_id)
+        # Initialize steering queue for this session. 同一 chat session 的并发
+        # run 共享同一组队列键，队列生命周期以 run 为单位计数：cleanup 只在
+        # 最后一个持有 run 退出时才真正删除队列。
+        steering_run_id = uuid.uuid4().hex
+        steering_queue = await create_steering_queue_async(
+            session_id, user_id, run_id=steering_run_id
+        )
 
         # Initialize tracking variables before try block for exception safety
         all_tool_calls: list[dict[str, Any]] = []
@@ -469,6 +486,41 @@ class AgentService:
         had_stream_error = False
         request_failed = False
         stream_cancelled = False
+        history_saved = False
+        history_save_task: asyncio.Task | None = None
+        cancellation_save_task: asyncio.Task | None = None
+
+        # Steering callback for the agent loop. 定义在 try 之前：取消/失败
+        # 路径的兜底 drain 也依赖它，不能等到工作流启动处才可用。
+        async def get_steering_messages():
+            """Get pending steering messages for agent loop."""
+            steering_pending = await steering_queue.get_pending()
+            payload = [{"id": m.id, "content": m.content} for m in steering_pending]
+            # Record what the run actually consumed so it can be persisted to
+            # chat history (otherwise node-boundary steering is lost on the
+            # next request).
+            consumed_steering.extend(
+                str(item["content"]) for item in payload if item.get("content")
+            )
+            return payload
+
+        def _save_partial_history_sync() -> None:
+            """用独立 session 落库部分历史（取消/失败路径，绕开共享 session）。"""
+            recovery_manager = MessageManager(
+                project_id=project_id,
+                user_id=user_id,
+            )
+            with create_session() as recovery_session:
+                recovery_manager._save_messages_with_session(
+                    recovery_session,
+                    session_id,
+                    message,
+                    assistant_response,
+                    all_tool_calls if all_tool_calls else None,
+                    reasoning_content if reasoning_content else None,
+                    assistant_status_cards=assistant_status_cards or None,
+                    steering_messages=consumed_steering or None,
+                )
 
         try:
             lang = (language or "").strip().lower() or "zh"
@@ -614,22 +666,17 @@ class AgentService:
             #
             # Assembled context (assembler ~6k) and chat history (~6k) used to be
             # budgeted independently and both injected (~12k+). Now they compete
-            # within ONE shared ceiling: subtract the already-known prompt costs
-            # (system prompt + skill catalog/reference + assembled context) from
-            # the ledger ceiling, then shrink the history window to whatever room
-            # remains. The DB-history persistence contract and the configured
+            # within ONE shared ceiling: subtract the already-known prompt cost
+            # from the ledger ceiling, then shrink the history window to whatever
+            # room remains. The DB-history persistence contract and the configured
             # dual budgets are unchanged — this only trims what is *loaded*.
+            #
+            # system_prompt 已由 build_system_prompt 内嵌 skill catalog /
+            # skill reference / assembled context，台账只按最终 prompt 计费一次，
+            # 避免同一段文本重复扣减历史预算。
             from agent.utils.token_utils import estimate_text_tokens
 
-            assembled_context_text = (
-                context_data.context if context_data and context_data.context else ""
-            )
-            reserved_prompt_tokens = (
-                estimate_text_tokens(system_prompt or "")
-                + estimate_text_tokens(skill_catalog or "")
-                + estimate_text_tokens(skill_reference or "")
-                + estimate_text_tokens(assembled_context_text or "")
-            )
+            reserved_prompt_tokens = estimate_text_tokens(system_prompt or "")
             effective_history_budget = compute_history_token_budget(
                 configured_history_budget=AGENT_CHAT_HISTORY_TOKEN_BUDGET,
                 reserved_prompt_tokens=reserved_prompt_tokens,
@@ -700,19 +747,6 @@ class AgentService:
                 user_id=user_id,
                 process_file_markers=True,
             )
-
-            # Add steering callback to agent loop
-            async def get_steering_messages():
-                """Get pending steering messages for agent loop."""
-                messages = await steering_queue.get_pending()
-                payload = [{"id": m.id, "content": m.content} for m in messages]
-                # Record what the run actually consumed so it can be persisted to
-                # chat history (otherwise node-boundary steering is lost on the
-                # next request).
-                consumed_steering.extend(
-                    str(item["content"]) for item in payload if item.get("content")
-                )
-                return payload
 
             try:
                 # Process through workflow stream
@@ -826,19 +860,54 @@ class AgentService:
                         tool_calls=len(all_tool_calls) if all_tool_calls else 0,
                     )
 
-                # Save to history
-                assistant_message_id = await message_manager.save_messages(
-                    session,
-                    session_id,
-                    message,
-                    assistant_response,
-                    all_tool_calls if all_tool_calls else None,
-                    reasoning_content if reasoning_content else None,
-                    assistant_stop_reason=assistant_stop_reason,
-                    assistant_usage=assistant_usage,
-                    assistant_status_cards=assistant_status_cards or None,
-                    steering_messages=consumed_steering or None,
-                )
+                # 工作流结束后队列里可能仍有未被任何消费点取走的 steering
+                # （协作轮数耗尽、或最后一轮 agent 收尾窗口才到达的消息）。
+                # 保存历史前统一取出，保证 /agent/steer 已确认 queued 的输入
+                # 随本轮落库，而不是被随后的 cleanup 静默删除。
+                try:
+                    await get_steering_messages()
+                except Exception as exc:
+                    log_with_context(
+                        logger,
+                        30,  # WARNING
+                        "Failed to drain remaining steering messages before history save",
+                        session_id=session_id,
+                        error=str(exc),
+                        error_type=type(exc).__name__,
+                    )
+
+                # Save to history。落库放进独立任务并 shield：PG 下
+                # save_messages 内部走 asyncio.to_thread，工作线程一旦启动就
+                # 无法取消（awaiting 侧抛 CancelledError，线程照样 commit）。
+                # shield 保证取消不会打断这次落库，且 history_saved 只在真正
+                # 写完后置位，取消分支据此跳过补偿保存，避免整轮历史写两遍。
+                async def _save_history_once() -> str | None:
+                    nonlocal history_saved
+                    saved_id = await message_manager.save_messages(
+                        session,
+                        session_id,
+                        message,
+                        assistant_response,
+                        all_tool_calls if all_tool_calls else None,
+                        reasoning_content if reasoning_content else None,
+                        assistant_stop_reason=assistant_stop_reason,
+                        assistant_usage=assistant_usage,
+                        assistant_status_cards=assistant_status_cards or None,
+                        steering_messages=consumed_steering or None,
+                    )
+                    history_saved = True
+                    return saved_id
+
+                def _consume_history_save_error(done_task: asyncio.Task) -> None:
+                    # 取消路径下可能没人再取这个任务的结果，先消费掉异常避免
+                    # "exception was never retrieved"；失败仍会由下面的 await
+                    # 传播成 error 事件。
+                    if not done_task.cancelled():
+                        done_task.exception()
+
+                history_save_task = asyncio.create_task(_save_history_once())
+                history_save_task.add_done_callback(_consume_history_save_error)
+                assistant_message_id = await asyncio.shield(history_save_task)
                 if pending_done_payload is not None:
                     refs_candidate = pending_done_payload.get("refs")
                     refs = refs_candidate if isinstance(refs_candidate, list) else None
@@ -863,6 +932,41 @@ class AgentService:
 
         except asyncio.CancelledError:
             stream_cancelled = True
+            # 前端取消/断连时事件循环正在退栈，此处任何 await 都会被同一个
+            # cancel 再次打断，且共享 session 会随请求关闭；因此与
+            # had_stream_error 分支同样保留部分历史（用户消息 + 已生成的
+            # assistant 内容 + 已完成 tool_calls + 已消费 steering），但改用
+            # 后台任务 + 独立 session 落库，随后原样向上传播取消。取消瞬间
+            # 队列里可能还有已确认 queued 但未消费的 steering，落库前先在
+            # 后台任务里 drain 进 consumed_steering，避免它们随队列清理丢失。
+            if user_id and not history_saved:
+
+                async def _drain_then_save_partial_history() -> None:
+                    # 取消可能恰好落在 save_messages 期间：它被 shield 保护会
+                    # 继续跑完，所以补偿保存前必须等它的真实结果，已落库就直接
+                    # 返回，否则同一轮 user/steering/assistant 会被重复写入。
+                    if history_save_task is not None:
+                        await asyncio.wait({history_save_task})
+                        if history_saved:
+                            return
+                    try:
+                        await get_steering_messages()
+                    except Exception as exc:
+                        log_with_context(
+                            logger,
+                            30,  # WARNING
+                            "Failed to drain steering queue before cancellation save",
+                            session_id=session_id,
+                            error=str(exc),
+                            error_type=type(exc).__name__,
+                        )
+                    await asyncio.to_thread(_save_partial_history_sync)
+
+                cancellation_save_task = self._schedule_background_cleanup(
+                    _drain_then_save_partial_history(),
+                    description="save_partial_history_after_cancellation",
+                    session_id=session_id,
+                )
             raise
         except Exception as e:
             request_failed = True
@@ -879,10 +983,20 @@ class AgentService:
             yield error_event(str(e)).to_sse()
 
         finally:
-            # Cleanup steering queue
+            # Cleanup steering queue（只释放本 run 的持有，并发 run 不受影响）
             if stream_cancelled:
+
+                async def _cleanup_after_cancellation_save() -> None:
+                    # 先等部分历史落库（其中包含 drain 出的 steering）再释放
+                    # 队列，避免清理任务抢先删掉尚未落库的消息。asyncio.wait
+                    # 不会向外抛保存任务的异常/取消，失败已由其 done callback
+                    # 记录，这里无论如何都要继续清理。
+                    if isinstance(cancellation_save_task, asyncio.Task):
+                        await asyncio.wait({cancellation_save_task})
+                    await cleanup_steering_queue_async(session_id, run_id=steering_run_id)
+
                 self._schedule_background_cleanup(
-                    cleanup_steering_queue_async(session_id),
+                    _cleanup_after_cancellation_save(),
                     description="cleanup_steering_queue_async",
                     session_id=session_id,
                 )
@@ -893,7 +1007,34 @@ class AgentService:
                     session_id=session_id,
                 )
             else:
-                await cleanup_steering_queue_async(session_id)
+                # cleanup 会连消息一起删除队列：先兜底取出仍未消费的
+                # steering（正常路径在保存历史前已 drain 过，这里主要覆盖
+                # 请求失败、未走到保存点的情况），有未落库的消费记录时连同
+                # 本轮用户消息一起补存，保证已确认 queued 的输入不会凭空消失。
+                try:
+                    await get_steering_messages()
+                except Exception as exc:
+                    log_with_context(
+                        logger,
+                        30,  # WARNING
+                        "Failed to drain steering queue before cleanup",
+                        session_id=session_id,
+                        error=str(exc),
+                        error_type=type(exc).__name__,
+                    )
+                if user_id and not history_saved and consumed_steering:
+                    try:
+                        await asyncio.to_thread(_save_partial_history_sync)
+                    except Exception as exc:
+                        log_with_context(
+                            logger,
+                            30,  # WARNING
+                            "Failed to persist steering messages after stream failure",
+                            session_id=session_id,
+                            error=str(exc),
+                            error_type=type(exc).__name__,
+                        )
+                await cleanup_steering_queue_async(session_id, run_id=steering_run_id)
 
             total_duration = int((utcnow() - start_time).total_seconds() * 1000)
             metrics.observe_histogram(AGENT_REQUESTS_DURATION_MS, total_duration)

--- a/apps/server/agent/stream_adapter.py
+++ b/apps/server/agent/stream_adapter.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
 
+from models.file_model import FILE_TYPE_FOLDER
 from utils.logger import get_logger, log_with_context
 
 from .core.events import (
@@ -67,6 +68,15 @@ STREAM_SKILL_USAGE_RECORD_TIMEOUT_S = _get_positive_float_env(
 
 # Regex pattern for skill usage marker: [使用技能: xxx]
 SKILL_USAGE_PATTERN = re.compile(r"\[使用技能:\s*(.+?)\]")
+
+
+def is_folder_file_type(raw: Any) -> bool:
+    """判断一个 file_type 值是否是文件夹（strip + lower 归一化，容忍 None/非字符串）。
+
+    与 mcp_tools 的 pending-empty-file 守卫必须用同一套判定：一处放行、一处
+    拦截会让 folder 只在其中一条路径上被排除（本次 C2 缺口的成因）。
+    """
+    return isinstance(raw, str) and raw.strip().lower() == FILE_TYPE_FOLDER
 
 
 @dataclass
@@ -177,7 +187,23 @@ class StreamAdapter:
             file_id: ID of the created file
             file_type: Type of the file
             title: Title of the file
+
+        Note:
+            start_file_write() 会清空 StreamProcessor 的缓冲。调用方若可能在
+            捕获进行中调用（正常路径就是「上一份文件还没写完又建了新档」），
+            必须先用 _flush_active_capture() 把已缓冲的内容吐出去，否则那段
+            叙述/正文会被静默丢弃。适配器自身的 create_file 处理已这样做。
         """
+        if self.config.process_file_markers and self._stream_processor.is_active:
+            log_with_context(
+                logger,
+                30,  # WARNING
+                "Overwriting an active file capture without flushing it first",
+                file_id=file_id,
+                previous_state=str(self._stream_processor.state),
+                previous_file_id=self._stream_processor.file_id,
+            )
+
         self._pending_file_write = PendingFileWrite(
             file_id=file_id,
             file_type=file_type,
@@ -244,9 +270,7 @@ class StreamAdapter:
         # so it cannot block create_file in any subsequent processing/request.
         if self._pending_file_write is not None:
             self._pending_file_write = None
-            with contextlib.suppress(Exception):
-                from agent.tools.mcp_tools import ToolContext
-                ToolContext.clear_pending_empty_file()
+            self._clear_pending_empty_file_guard()
 
         # Ensure content_end is sent if content was started
         if self._content_started:
@@ -486,7 +510,8 @@ class StreamAdapter:
 
             # Handle file creation
             if tool_name == "create_file" and status == "success":
-                await self._handle_create_file_result(result_data)
+                async for event in self._handle_create_file_result(result_data):
+                    yield event
                 file_data = result_data if isinstance(result_data, dict) else {}
                 if file_data:
                     file_id = file_data.get("id", "")
@@ -565,16 +590,63 @@ class StreamAdapter:
 
         return ""
 
-    async def _handle_create_file_result(self, result_data: Any) -> None:
-        """Set up pending file write if file was created empty."""
+    async def _handle_create_file_result(
+        self,
+        result_data: Any,
+    ) -> AsyncIterator[SSEEvent]:
+        """Set up pending file write if a content-bearing file was created empty.
+
+        Yields SSE events for the previous capture when a new pending write
+        displaces one that is still buffering.
+        """
         file_data = result_data if isinstance(result_data, dict) else {}
-        if file_data:
-            file_id = file_data.get("id", "")
-            file_type = file_data.get("file_type", "")
-            title = file_data.get("title", "")
-            content = file_data.get("content", "")
-            if not content and file_id:
-                self.set_pending_file_write(file_id, file_type, title)
+        if not file_data:
+            return
+
+        file_id = file_data.get("id", "")
+        content = file_data.get("content", "")
+        if content or not file_id:
+            return
+
+        file_type = file_data.get("file_type", "")
+        # folder 是纯容器节点，永远不会收到 <file>…</file> 正文。给它开启流式
+        # 捕获会把后续叙述全部扣在 WAITING_START 缓冲里（前端长时间无输出），
+        # 并让流结束时的 at_eof 兜底把叙述当正文 update_file 写进文件夹行。
+        # 与 mcp_tools 的 pending-empty-file 守卫保持同一套 folder 判定。
+        if is_folder_file_type(file_type):
+            log_with_context(
+                logger,
+                20,  # INFO
+                "Skipping pending file write for folder node",
+                file_id=file_id,
+                file_type=file_type,
+                title=file_data.get("title", ""),
+            )
+            return
+
+        # 上一段捕获可能仍在缓冲（WAITING_START 的叙述 / WRITING 的正文）：
+        # 先收尾并把内容吐出去，再切到新文件，避免 start_file_write() 清空
+        # 缓冲造成静默丢失。
+        async for sse_event in self._flush_active_capture():
+            yield sse_event
+        if self._fatal_stream_error:
+            return
+
+        self.set_pending_file_write(file_id, file_type, file_data.get("title", ""))
+
+    async def _flush_active_capture(self) -> AsyncIterator[SSEEvent]:
+        """收尾仍在进行中的流式捕获，并发出对应的 SSE 事件。
+
+        复用 finalize_on_stream_end 的语义：WAITING_START 的缓冲原样回到对话，
+        WRITING 的正文按截断补全（含 control-marker 污染守卫），DRAINING 的
+        溢出尾部丢弃。
+        """
+        if not (self.config.process_file_markers and self._stream_processor.is_active):
+            return
+
+        result = self._stream_processor.finalize_on_stream_end()
+        async for sse_event in self._emit_stream_result(result):
+            yield sse_event
 
     async def _handle_text_content(self, text: str) -> AsyncIterator[SSEEvent]:
         """
@@ -630,9 +702,7 @@ class StreamAdapter:
                 self._fatal_stream_error = True
                 # Clear pending state to avoid blocking future create_file calls.
                 self._pending_file_write = None
-                with contextlib.suppress(Exception):
-                    from agent.tools.mcp_tools import ToolContext
-                    ToolContext.clear_pending_empty_file()
+                self._clear_pending_empty_file_guard(result.file_id)
                 yield error_event(
                     message="Failed to persist streamed file content",
                     code="FILE_SAVE_FAILED",
@@ -646,8 +716,25 @@ class StreamAdapter:
         self._pending_file_write = None
 
         # Also clear ToolContext pending state, allowing next create_file.
+        self._clear_pending_empty_file_guard(result.file_id)
+
+    def _clear_pending_empty_file_guard(self, file_id: str = "") -> None:
+        """清除 ToolContext 的 pending-empty-file 标记。
+
+        传入 file_id 时只清除指向该文件的标记：一份仍在缓冲的文件被新的
+        create_file 顶掉时，标记可能已经指向新建的空文件，若被上一份文件的
+        收尾误清，「空文件必须被补写」的信号就丢了（writing_graph 再也不会
+        安排补写）。file_id 为空表示流结束时的无条件清理，避免标记泄漏到
+        下一个请求。
+        """
         with contextlib.suppress(Exception):
             from agent.tools.mcp_tools import ToolContext
+
+            if file_id:
+                pending = ToolContext.get_pending_empty_file()
+                pending_id = pending.get("file_id") if pending else ""
+                if pending_id and pending_id != file_id:
+                    return
             ToolContext.clear_pending_empty_file()
 
     async def _save_file_content(self, file_id: str, content: str) -> bool:
@@ -1031,4 +1118,5 @@ __all__ = [
     "StreamAdapterConfig",
     "PendingFileWrite",
     "create_stream_adapter",
+    "is_folder_file_type",
 ]

--- a/apps/server/agent/tools/file_ops/crud.py
+++ b/apps/server/agent/tools/file_ops/crud.py
@@ -20,6 +20,7 @@ from sqlalchemy import func
 from sqlmodel import Session, col, select
 
 from agent.tools.permissions import (
+    check_file_access_in_tool_context,
     check_project_ownership,
 )
 from config.datetime_utils import utcnow
@@ -35,6 +36,7 @@ from utils.title_sequence import (
     resolve_persisted_sequence_order,
 )
 
+from .edit import file_write_lock
 from .serialization import (
     QUERY_FILES_DEFAULT_CONTENT_PREVIEW_CHARS,
     QUERY_FILES_DEFAULT_RESPONSE_MODE,
@@ -464,6 +466,26 @@ class FileCRUD:
             PermissionError: If user doesn't have permission
             ValueError: If file not found
         """
+        from database import is_postgres
+
+        if is_postgres:
+            return self._update_file_impl(id, title, content, parent_id, order, metadata)
+        # SQLite has no row locks: serialize same-file writes with the
+        # in-process per-file lock (shared with edit_file) so concurrent
+        # tasks cannot interleave between our read, commit and version
+        # snapshot.
+        with file_write_lock(id):
+            return self._update_file_impl(id, title, content, parent_id, order, metadata)
+
+    def _update_file_impl(
+        self,
+        id: str,
+        title: str | None,
+        content: str | None,
+        parent_id: str | None,
+        order: int | None,
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
         log_with_context(
             logger,
             20,  # INFO
@@ -475,8 +497,20 @@ class FileCRUD:
             content_length=len(content) if content else 0,
         )
 
-        # Get file
-        file = self.session.get(File, id)
+        # Get file. Same locking/read discipline as FileEditor.edit_file: on
+        # PostgreSQL hold a row lock (FOR NO KEY UPDATE, so the version
+        # snapshot's FK insert from its independent session is not blocked)
+        # until both content and snapshot are written; on SQLite force a
+        # re-SELECT past the shared session's identity map so the update is
+        # based on current DB state instead of a stale cached instance.
+        from database import is_postgres
+
+        if is_postgres:
+            file = self.session.exec(
+                select(File).where(File.id == id).with_for_update(key_share=True)
+            ).first()
+        else:
+            file = self.session.get(File, id, populate_existing=True)
 
         if not file:
             # Do not leak internal IDs to end users
@@ -489,8 +523,8 @@ class FileCRUD:
             )
             raise ValueError("文件不存在或已删除")
 
-        # Check permission
-        check_project_ownership(self.session, file.project_id, self.user_id)
+        # Check permission (target must belong to the current tool-context project)
+        check_file_access_in_tool_context(self.session, file, self.user_id)
 
         # Store old content for version history
         old_content = file.content
@@ -530,11 +564,19 @@ class FileCRUD:
         # Check if content changed
         content_changed = content is not None and content != old_content
 
+        # Keep the version snapshot ordered with the content commit (see
+        # FileEditor._edit_file_impl for the full rationale): on PostgreSQL
+        # snapshot BEFORE commit while the row lock is still held; on SQLite
+        # snapshot after commit, inside the per-file lock, because the
+        # snapshot's independent session must commit while this session holds
+        # no write transaction.
+        if content_changed and is_postgres:
+            self._create_version(id, content)
+
         self.session.commit()
         self.session.refresh(file)
 
-        # Create version history for content changes (AI edit)
-        if content_changed:
+        if content_changed and not is_postgres:
             self._create_version(id, content)
 
         # Fire-and-forget vector index upsert (do not block)
@@ -594,8 +636,8 @@ class FileCRUD:
             )
             raise ValueError("文件不存在或已删除")
 
-        # Check permission
-        check_project_ownership(self.session, file.project_id, self.user_id)
+        # Check permission (target must belong to the current tool-context project)
+        check_file_access_in_tool_context(self.session, file, self.user_id)
 
         deleted: list[File] = []
 
@@ -704,29 +746,17 @@ class FileCRUD:
         elif file_type:
             target_types = [file_type]
 
-        # If querying specific types, search each type separately
-        if target_types:
-            results = []
-            for ft in target_types:
-                type_results = self._query_single_type(
-                    project_id=project_id,
-                    file_type=ft,
-                    query=query,
-                    parent_id=parent_id,
-                    limit=limit,
-                    offset=offset,
-                )
-                results.extend(type_results)
-        else:
-            # Query all types at once
-            results = self._query_single_type(
-                project_id=project_id,
-                file_type=None,
-                query=query,
-                parent_id=parent_id,
-                limit=limit,
-                offset=offset,
-            )
+        # limit/offset apply to the MERGED result set (a single statement),
+        # so the declared "max results" cap and pagination semantics hold even
+        # when multiple file_types are requested.
+        results = self._query_files_page(
+            project_id=project_id,
+            file_types=target_types,
+            query=query,
+            parent_id=parent_id,
+            limit=limit,
+            offset=offset,
+        )
 
         # Apply metadata filter in Python (SQLite JSON support is limited)
         if metadata_filter:
@@ -794,21 +824,24 @@ class FileCRUD:
 
     # ========== Helper Methods ==========
 
-    def _query_single_type(
+    def _query_files_page(
         self,
         project_id: str,
-        file_type: str | None,
+        file_types: list[str] | None,
         query: str | None,
         parent_id: str | None,
         limit: int,
         offset: int,
     ) -> list[File]:
         """
-        Query files of a single type (or all types).
+        Query one page of files, optionally filtered to the given types.
+
+        limit/offset are applied to the single combined statement, so they
+        keep their declared semantics regardless of how many types are given.
 
         Args:
             project_id: Project ID
-            file_type: File type filter (None for all types)
+            file_types: File type filter (None for all types)
             query: Search keyword (optional)
             parent_id: Parent ID filter (optional)
             limit: Max results
@@ -824,8 +857,8 @@ class FileCRUD:
         )
 
         # Apply file type filter
-        if file_type:
-            stmt = stmt.where(File.file_type == file_type)
+        if file_types:
+            stmt = stmt.where(File.file_type.in_(file_types))  # type: ignore[attr-defined]
 
         # Apply keyword search
         if query:
@@ -837,8 +870,14 @@ class FileCRUD:
         if parent_id is not None:
             stmt = stmt.where(File.parent_id == parent_id)
 
-        # Order and paginate
-        stmt = stmt.order_by(File.order.asc(), col(File.created_at).desc())  # type: ignore[attr-defined]
+        # Order and paginate. The id tiebreaker makes the total order
+        # deterministic so pagination cannot duplicate/skip rows when
+        # order/created_at tie across types.
+        stmt = stmt.order_by(
+            File.order.asc(),  # type: ignore[attr-defined]
+            col(File.created_at).desc(),
+            col(File.id).asc(),
+        )
         stmt = stmt.offset(offset).limit(limit)
 
         return list(self.session.exec(stmt).all())

--- a/apps/server/agent/tools/file_ops/edit.py
+++ b/apps/server/agent/tools/file_ops/edit.py
@@ -10,12 +10,13 @@ the LLM provides slightly different text.
 Extracted from the monolithic file_executor.py for better maintainability.
 """
 
+import threading
 from typing import Any
 
 from services.file_version import FileVersionService
 from sqlmodel import Session, select
 
-from agent.tools.permissions import check_project_ownership
+from agent.tools.permissions import check_file_access_in_tool_context
 from config.datetime_utils import utcnow
 from models import File
 from models.file_version import (
@@ -33,6 +34,25 @@ from .text_matching import (
 )
 
 logger = get_logger(__name__)
+
+# Cap for replace_all fuzzy scanning. The exact-match path replaces EVERY
+# occurrence, so the fuzzy path must not silently stop at a handful; this cap
+# only guards pathological inputs and is surfaced as an explicit warning when
+# actually hit.
+REPLACE_ALL_MAX_FUZZY_MATCHES = 1000
+
+# SQLite has no row-level locks, so same-file read-modify-write sections are
+# serialized with in-process striped locks instead (the default SQLite
+# deployment runs a single server process; cross-process SQLite writers are
+# not covered). Striping keeps memory bounded; distinct files may share a
+# stripe, which only costs some extra serialization.
+_FILE_WRITE_LOCK_STRIPES = 64
+_file_write_locks = [threading.Lock() for _ in range(_FILE_WRITE_LOCK_STRIPES)]
+
+
+def file_write_lock(file_id: str) -> threading.Lock:
+    """Return the in-process write lock striped by ``file_id``."""
+    return _file_write_locks[hash(file_id) % _FILE_WRITE_LOCK_STRIPES]
 
 
 def _exact_spans(content: str, sub: str, limit: int = 3) -> list[tuple[int, int]]:
@@ -111,20 +131,44 @@ class FileEditor:
             ValueError: If file not found or edit operation fails
             PermissionError: If user doesn't have permission
         """
+        from database import is_postgres
+
+        if is_postgres:
+            return self._edit_file_impl(id, edits, continue_on_error)
+        # SQLite has no row locks: serialize same-file read-modify-write with
+        # the in-process per-file lock so a concurrent edit (parallel_execute
+        # runs each task on its own session/thread) cannot interleave between
+        # our read and commit.
+        with file_write_lock(id):
+            return self._edit_file_impl(id, edits, continue_on_error)
+
+    def _edit_file_impl(
+        self,
+        id: str,
+        edits: list[dict[str, Any]],
+        continue_on_error: bool,
+    ) -> dict[str, Any]:
         # Get file. On PostgreSQL take a row lock so concurrent edit_file tasks
         # (parallel_execute runs each on its own session) targeting the SAME file
-        # serialize: the second SELECT ... FOR UPDATE blocks until the first
-        # commits and then re-reads the updated content, preventing a lost update
-        # where the later commit overwrites the earlier edit. SQLite has no row
-        # locking (and its file lock already serializes writers), so fall back.
+        # serialize: the second locked SELECT blocks until the first commits and
+        # then re-reads the updated content, preventing a lost update where the
+        # later commit overwrites the earlier edit. FOR NO KEY UPDATE (not FOR
+        # UPDATE) so the version snapshot's FK insert from its independent
+        # session (KEY SHARE on this row) is not blocked by the held lock.
         from database import is_postgres
 
         if is_postgres:
             file = self.session.exec(
-                select(File).where(File.id == id).with_for_update()
+                select(File).where(File.id == id).with_for_update(key_share=True)
             ).first()
         else:
-            file = self.session.get(File, id)
+            # The shared per-request session may already hold this File in its
+            # identity map from context assembly (minutes before this edit);
+            # Session.get would return that cached snapshot without any SQL.
+            # Force a re-SELECT so the read-modify-write is based on the
+            # current DB content, not on a stale copy that would silently
+            # overwrite a concurrent user save.
+            file = self.session.get(File, id, populate_existing=True)
 
         if not file or file.is_deleted:
             # Do not leak internal IDs to end users
@@ -137,8 +181,8 @@ class FileEditor:
             )
             raise ValueError("文件不存在或已删除")
 
-        # Check permission
-        check_project_ownership(self.session, file.project_id, self.user_id)
+        # Check permission (target must belong to the current tool-context project)
+        check_file_access_in_tool_context(self.session, file, self.user_id)
 
         old_content = file.content or ""
         content = old_content
@@ -270,16 +314,25 @@ class FileEditor:
                 })
                 warnings.append(f"Edit {i}: failed and skipped ({e})")
 
-        # Update file only when content changed.
+        # Update file only when content changed. The version snapshot must
+        # stay ordered with the content commit for the same file:
+        # - PostgreSQL: write the snapshot BEFORE committing, because commit
+        #   releases the row lock and a competing edit could then commit and
+        #   snapshot first, leaving the newest version number pointing at
+        #   older content. Snapshot failure never blocks the edit itself.
+        # - SQLite: the in-process per-file lock (see edit_file) covers both
+        #   the commit and the snapshot, but the snapshot's independent
+        #   session must commit while this session holds no write
+        #   transaction, so it runs AFTER the content commit.
         if content != old_content:
             file.content = content
             file.updated_at = utcnow()
+            if is_postgres:
+                self._create_edit_version(id, content, applied_edits)
             self.session.commit()
             self.session.refresh(file)
-
-        # Create version history for AI edit
-        if content != old_content:
-            self._create_edit_version(id, content, applied_edits)
+            if not is_postgres:
+                self._create_edit_version(id, content, applied_edits)
 
         return {
             "id": file.id,
@@ -407,11 +460,20 @@ class FileEditor:
                 )
 
             # 2) Fuzzy match (ignore punctuation/whitespace)
+            # replace_all mirrors the exact path (which replaces EVERY
+            # occurrence), so it must not stop at the default 20-match cap.
+            fuzzy_stats: dict[str, int] = {}
             spans = find_fuzzy_spans(
                 content,
                 old_text,
                 ignore_punct_whitespace=ignore_punct_whitespace,
+                max_matches=REPLACE_ALL_MAX_FUZZY_MATCHES if replace_all else 20,
+                stats=fuzzy_stats,
             )
+            if fuzzy_stats.get("boundary_rejected"):
+                warnings.append(
+                    f"Edit {edit_index}: {fuzzy_stats['boundary_rejected']} 处候选匹配因字符归一化展开边界不对齐被跳过（如罗马数字/合字），已避免吞掉未匹配的原文"
+                )
 
             # 3) If fuzzy match fails, try approximate match (handles word errors)
             approx_match = None
@@ -447,17 +509,34 @@ class FileEditor:
                 )
 
             if replace_all:
-                # Replace from tail to head to keep indices stable
-                for start, end in reversed(spans):
-                    content = content[:start] + new_text + content[end:]
-                applied_edits.append({
+                # Stitch segments in one pass (spans are sorted and
+                # non-overlapping); repeated re-slicing would be O(n·k).
+                parts: list[str] = []
+                prev = 0
+                for start, end in spans:
+                    parts.append(content[prev:start])
+                    parts.append(new_text)
+                    prev = end
+                parts.append(content[prev:])
+                content = "".join(parts)
+
+                truncated = len(spans) >= REPLACE_ALL_MAX_FUZZY_MATCHES
+                if truncated:
+                    warnings.append(
+                        f"Edit {edit_index}: replace_all 近似匹配达到 {REPLACE_ALL_MAX_FUZZY_MATCHES} 处上限，"
+                        f"可能仍有未替换的出现，请检查剩余内容"
+                    )
+                detail = {
                     "op": "replace",
                     "match_mode": "fuzzy",
                     "ignore_punct_whitespace": ignore_punct_whitespace,
                     "old_preview": old_text[:200] + ("..." if len(old_text) > 200 else ""),
                     "new_preview": new_text[:200] + ("..." if len(new_text) > 200 else ""),
                     "count": len(spans),
-                })
+                }
+                if truncated:
+                    detail["truncated"] = True
+                applied_edits.append(detail)
             else:
                 if len(spans) != 1:
                     previews = build_span_previews(content, spans)
@@ -484,7 +563,7 @@ class FileEditor:
         edit: dict[str, Any],
         edit_index: int,
         applied_edits: list[dict[str, Any]],
-        _warnings: list[str],
+        warnings: list[str],
     ) -> str:
         """Apply an insert_after edit operation."""
         anchor = edit.get("anchor", "")
@@ -518,11 +597,17 @@ class FileEditor:
                     f"Edit {edit_index}: anchor text not found in content (exact match)"
                 )
 
+            fuzzy_stats: dict[str, int] = {}
             spans = find_fuzzy_spans(
                 content,
                 anchor,
                 ignore_punct_whitespace=ignore_punct_whitespace,
+                stats=fuzzy_stats,
             )
+            if fuzzy_stats.get("boundary_rejected"):
+                warnings.append(
+                    f"Edit {edit_index}: {fuzzy_stats['boundary_rejected']} 处候选锚点因字符归一化展开边界不对齐被跳过（如罗马数字/合字）"
+                )
             if not spans:
                 # Secondary fallback: approximate match (handles word errors)
                 approx_match = find_approximate_match(
@@ -617,7 +702,7 @@ class FileEditor:
         edit: dict[str, Any],
         edit_index: int,
         applied_edits: list[dict[str, Any]],
-        _warnings: list[str],
+        warnings: list[str],
     ) -> str:
         """Apply an insert_before edit operation."""
         anchor = edit.get("anchor", "")
@@ -650,11 +735,17 @@ class FileEditor:
                     f"Edit {edit_index}: anchor text not found in content (exact match)"
                 )
 
+            fuzzy_stats: dict[str, int] = {}
             spans = find_fuzzy_spans(
                 content,
                 anchor,
                 ignore_punct_whitespace=ignore_punct_whitespace,
+                stats=fuzzy_stats,
             )
+            if fuzzy_stats.get("boundary_rejected"):
+                warnings.append(
+                    f"Edit {edit_index}: {fuzzy_stats['boundary_rejected']} 处候选锚点因字符归一化展开边界不对齐被跳过（如罗马数字/合字）"
+                )
             if not spans:
                 # Secondary fallback: approximate match (handles word errors)
                 approx_match = find_approximate_match(
@@ -784,11 +875,17 @@ class FileEditor:
                     f"Edit {edit_index}: text to delete not found in content (exact match)"
                 )
 
+            fuzzy_stats: dict[str, int] = {}
             spans = find_fuzzy_spans(
                 content,
                 old_text,
                 ignore_punct_whitespace=ignore_punct_whitespace,
+                stats=fuzzy_stats,
             )
+            if fuzzy_stats.get("boundary_rejected"):
+                warnings.append(
+                    f"Edit {edit_index}: {fuzzy_stats['boundary_rejected']} 处候选匹配因字符归一化展开边界不对齐被跳过（如罗马数字/合字），已避免误删原文"
+                )
             if not spans:
                 suggestions = suggest_similar_lines(
                     content,

--- a/apps/server/agent/tools/file_ops/text_matching.py
+++ b/apps/server/agent/tools/file_ops/text_matching.py
@@ -84,6 +84,7 @@ def find_fuzzy_spans(
     casefold: bool = True,
     min_normalized_len: int = 6,
     max_matches: int = 20,
+    stats: dict[str, int] | None = None,
 ) -> list[tuple[int, int]]:
     """Find match spans in original content, ignoring punctuation/whitespace.
 
@@ -97,11 +98,17 @@ def find_fuzzy_spans(
         casefold: If True, perform case-insensitive matching
         min_normalized_len: Minimum normalized pattern length to search
         max_matches: Maximum number of matches to return
+        stats: Optional dict receiving match diagnostics; "boundary_rejected"
+            counts candidates dropped because the span started/ended inside an
+            NFKC-expanded original character
 
     Returns:
         List of (start_index, end_index) tuples in the ORIGINAL content.
         Spans are non-overlapping and sorted by position.
     """
+    if stats is not None:
+        stats["boundary_rejected"] = 0
+
     normalized_content, map_content = normalize_for_fuzzy_match(
         content,
         ignore_punct_whitespace=ignore_punct_whitespace,
@@ -119,14 +126,31 @@ def find_fuzzy_spans(
         return []
 
     spans: list[tuple[int, int]] = []
+    boundary_rejected = 0
     pos = 0
     while pos < len(normalized_content):
         found = normalized_content.find(normalized_pattern, pos)
         if found < 0:
             break
 
+        last = found + len(normalized_pattern) - 1
+        # NFKC can expand one original char into several normalized chars
+        # (Ⅻ→xii, ﬁ→fi, ㎞→km); index_map maps all of them back to the same
+        # original index. A span starting/ending inside such an expansion
+        # would pull the WHOLE original char into the span and destroy its
+        # unmatched remainder, so only accept spans whose normalized
+        # boundaries align with original-char boundaries.
+        start_aligned = found == 0 or map_content[found] != map_content[found - 1]
+        end_aligned = (
+            last + 1 >= len(map_content) or map_content[last] != map_content[last + 1]
+        )
+        if not (start_aligned and end_aligned):
+            boundary_rejected += 1
+            pos = found + 1
+            continue
+
         start_orig = map_content[found]
-        end_orig = map_content[found + len(normalized_pattern) - 1] + 1
+        end_orig = map_content[last] + 1
         spans.append((start_orig, end_orig))
 
         if len(spans) >= max_matches:
@@ -135,6 +159,8 @@ def find_fuzzy_spans(
         # Non-overlapping by default for stability
         pos = found + len(normalized_pattern)
 
+    if stats is not None:
+        stats["boundary_rejected"] = boundary_rejected
     return spans
 
 
@@ -246,9 +272,19 @@ def find_approximate_match(
         return None
 
     start_i, end_i = best_span
+    end_i = min(end_i, len(map_content))
+    # Snap the window to original-char boundaries: a boundary landing inside
+    # an NFKC expansion (Ⅻ→xii etc.) would otherwise swallow the whole
+    # original char including its unmatched remainder, so shrink the span to
+    # exclude partially-covered chars instead.
+    while start_i < end_i and start_i > 0 and map_content[start_i] == map_content[start_i - 1]:
+        start_i += 1
+    while end_i > start_i and end_i < len(map_content) and map_content[end_i - 1] == map_content[end_i]:
+        end_i -= 1
+    if start_i >= end_i:
+        return None
     start_orig = map_content[start_i]
-    end_idx = min(end_i - 1, len(map_content) - 1)
-    end_orig = map_content[end_idx] + 1
+    end_orig = map_content[end_i - 1] + 1
     matched_text = content[start_orig:end_orig]
     return (start_orig, end_orig, best_score, matched_text)
 

--- a/apps/server/agent/tools/mcp_tools.py
+++ b/apps/server/agent/tools/mcp_tools.py
@@ -107,6 +107,25 @@ _pending_empty_file_var: contextvars.ContextVar[dict[str, str] | None] = context
 )
 
 
+class _PendingEmptyFileState:
+    """待写入空文件标记的可变持有者，随请求上下文 dict 在所有子任务间共享。
+
+    IMPORTANT — 该标记不能存成独立 ContextVar：openai-agents SDK 会为 run loop
+    以及每一次 function tool 调用各包一层 asyncio.create_task，而 create_task 只
+    拷贝当前 contextvars 快照，子任务里对 ContextVar 的重绑定对父上下文与兄弟
+    任务均不可见（同理 asyncio.to_thread / asyncio.gather 的子任务）。因此这里
+    只能原地修改这个持有者对象——set_context 在请求主上下文把它放进
+    _tool_context_var 持有的 dict 后，所有子任务的上下文副本（含
+    set_current_agent、parallel_executor task_ctx 的浅拷贝）引用的都是同一个
+    实例，原地读写天然跨任务可见。
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value: dict[str, str] | None = None
+
+
 class ToolContext:
     """
     Holds session and user_id for tool execution.
@@ -134,6 +153,7 @@ class ToolContext:
             "session_id": session_id,
             "create_session_func": create_session_func,
             "current_agent": current_agent,
+            "pending_empty_file_state": _PendingEmptyFileState(),
         })
         _owned_session_var.set(None)
         _pending_empty_file_var.set(None)
@@ -228,27 +248,53 @@ class ToolContext:
     def clear_context(cls) -> None:
         """Clear context and clean up owned session."""
         cls._cleanup_owned_session()
+        # 先清空共享持有者：其它任务里仍存活的上下文副本引用同一个对象，
+        # 仅把本上下文的 ContextVar 置 None 无法让它们看到清理结果。
+        state = cls._get_pending_empty_file_state()
+        if state is not None:
+            state.value = None
         _tool_context_var.set(None)
         _pending_empty_file_var.set(None)
 
     @classmethod
+    def _get_pending_empty_file_state(cls) -> _PendingEmptyFileState | None:
+        """获取请求上下文中跨任务共享的待写入文件持有者（未建上下文时为 None）。"""
+        context = _tool_context_var.get()
+        if isinstance(context, dict):
+            state = context.get("pending_empty_file_state")
+            if isinstance(state, _PendingEmptyFileState):
+                return state
+        return None
+
+    @classmethod
     def set_pending_empty_file(cls, file_id: str, title: str) -> None:
         """标记有一个空文件等待流式写入。"""
+        state = cls._get_pending_empty_file_state()
+        if state is not None:
+            state.value = {"file_id": file_id, "title": title}
+            return
+        # 未调用 set_context 的场景（如直接 set/get 的单测）退回本上下文的 ContextVar
         _pending_empty_file_var.set({"file_id": file_id, "title": title})
 
     @classmethod
     def clear_pending_empty_file(cls) -> None:
         """清除待写入文件标记。"""
+        state = cls._get_pending_empty_file_state()
+        if state is not None:
+            state.value = None
         _pending_empty_file_var.set(None)
 
     @classmethod
     def has_pending_empty_file(cls) -> bool:
         """检查是否有待写入的空文件。"""
-        return _pending_empty_file_var.get() is not None
+        return cls.get_pending_empty_file() is not None
 
     @classmethod
     def get_pending_empty_file(cls) -> dict[str, str] | None:
         """获取待写入的空文件信息。"""
+        state = cls._get_pending_empty_file_state()
+        if state is not None:
+            return state.value
         return _pending_empty_file_var.get()
 
     @classmethod
@@ -837,40 +883,23 @@ def _format_tool_result_overflow_backfill_context(backfills: list[dict[str, Any]
     return "\n".join(lines)
 
 
-def _extract_created_empty_file_id(result: dict[str, Any]) -> str:
-    """Pull the new file id out of a successful create_file MCP result envelope."""
-    try:
-        content = result.get("content") if isinstance(result, dict) else None
-        if not isinstance(content, list) or not content:
-            return ""
-        text = content[0].get("text", "") if isinstance(content[0], dict) else ""
-        payload = json.loads(text) if text else {}
-        if not isinstance(payload, dict) or payload.get("status") != "success":
-            return ""
-        data = payload.get("data")
-        return data.get("id", "") if isinstance(data, dict) else ""
-    except Exception:
-        return ""
+def _is_folder_file_type(result: dict[str, Any], args: dict[str, Any]) -> bool:
+    """判断刚创建的节点是否是文件夹（以执行器落库后的类型为准，回退到入参）。"""
+    raw = result.get("file_type") if isinstance(result, dict) else None
+    if not isinstance(raw, str) or not raw.strip():
+        raw = args.get("file_type") if isinstance(args, dict) else None
+    return isinstance(raw, str) and raw.strip().lower() == "folder"
 
 
 async def create_file(args: dict[str, Any]) -> dict[str, Any]:
     """创建新文件。"""
     if _should_offload_tool_execution():
-        result = await asyncio.to_thread(
+        # asyncio.to_thread 运行在拷贝上下文中，但 pending-empty-file 标记通过
+        # 请求上下文 dict 里的共享持有者原地修改，_create_file_sync 在工作线程
+        # 里设置后对主上下文同样可见，无需在此回填。
+        return await asyncio.to_thread(
             _run_sync_tool_with_owned_session_cleanup, _create_file_sync, args
         )
-        # The pending-empty-file marker is a ContextVar. On the Postgres offload
-        # path _create_file_sync runs inside asyncio.to_thread, which executes in
-        # a COPIED context, so the marker it sets there never reaches this
-        # (event-loop) context. Re-apply it here so the consecutive-empty-file
-        # guard and the writing_graph abandoned-empty-file correction loop — both
-        # of which read has_pending_empty_file() in the main context — work in
-        # production, not just under SQLite (where no offload happens).
-        if not args.get("content", ""):
-            file_id = _extract_created_empty_file_id(result)
-            if file_id:
-                ToolContext.set_pending_empty_file(file_id, args.get("title", ""))
-        return result
     return _create_file_sync(args)
 
 
@@ -915,7 +944,10 @@ def _create_file_sync(args: dict[str, Any]) -> dict[str, Any]:
         )
 
         # 如果创建的是空文件，标记为待写入
-        if not content:
+        # folder 例外：文件夹是纯容器节点，永远不会收到 <file>…</file> 正文，
+        # 给它置标记后无人清除（标记跨子任务可见），会硬阻断本轮后续所有建档，
+        # 并让 writing_graph 的纠偏分支把章节正文追加到文件夹节点上。
+        if not content and not _is_folder_file_type(result, args):
             file_id = result.get("id", "")
             if file_id:
                 ToolContext.set_pending_empty_file(file_id, title)
@@ -943,6 +975,12 @@ def _edit_file_sync(args: dict[str, Any]) -> dict[str, Any]:
     """Synchronous edit_file implementation."""
     tool_name = "edit_file"
     executor = ToolContext.get_executor()
+    project_id = ToolContext._get_context().get("project_id")
+
+    # 写工具必须运行在绑定了项目的上下文中；执行器层会进一步校验目标文件
+    # 属于该项目（check_file_access_in_tool_context）。
+    if project_id is None:
+        return _make_error("project_id not set", tool_name=tool_name)
 
     try:
         file_id_raw = args.get("id") or args.get("file_id") or args.get("fileId")
@@ -1000,6 +1038,12 @@ def _delete_file_sync(args: dict[str, Any]) -> dict[str, Any]:
     """Synchronous delete_file implementation."""
     tool_name = "delete_file"
     executor = ToolContext.get_executor()
+    project_id = ToolContext._get_context().get("project_id")
+
+    # 删除工具必须运行在绑定了项目的上下文中；执行器层会进一步校验目标文件
+    # 属于该项目（check_file_access_in_tool_context）。
+    if project_id is None:
+        return _make_error("project_id not set", tool_name=tool_name)
 
     try:
         result = executor.delete_file(

--- a/apps/server/agent/tools/permissions.py
+++ b/apps/server/agent/tools/permissions.py
@@ -113,8 +113,9 @@ def check_file_ownership(
         The File object if authorized
 
     Raises:
-        NotFoundError: If file doesn't exist
-        ForbiddenError: If file doesn't belong to project or user lacks access
+        NotFoundError: If file doesn't exist, or doesn't belong to the project
+            (跨项目访问对调用方表现为"文件不存在"，不泄漏其它项目文件的存在性)
+        ForbiddenError: If user lacks access to the project
     """
     # First check project access
     check_project_ownership(session, project_id, user_id)
@@ -125,11 +126,59 @@ def check_file_ownership(
     if not file or file.is_deleted:
         raise NotFoundError(f"File not found: {file_id}")
 
-    # Verify file belongs to the project
+    # Verify file belongs to the project. A mismatch is reported as not-found:
+    # 按 id 探测其它项目的文件不应得到与"不存在"可区分的响应；真实原因只进日志。
     if file.project_id != project_id:
-        raise ForbiddenError(f"File {file_id} does not belong to project {project_id}")
+        log_with_context(
+            logger,
+            40,  # ERROR
+            "File does not belong to requested project",
+            file_id=file_id,
+            file_project_id=file.project_id,
+            requested_project_id=project_id,
+            user_id=user_id,
+        )
+        raise NotFoundError(f"File not found: {file_id}")
 
     return file
+
+
+def check_file_access_in_tool_context(
+    session: Session,
+    file: File,
+    user_id: str | None = None,
+) -> None:
+    """
+    Check by-id file access for agent tool execution.
+
+    Agent 工具按 id 定位文件时，目标必须属于当前 ToolContext 绑定的项目：
+    根文件夹 id 可由 project_id 推出（如 "{project_id}-draft-folder"），仅靠
+    "用户拥有该文件所在项目"不足以阻止被注入文本诱导的跨项目写/删。
+    未绑定工具上下文的调用（stream_adapter 落盘、后台任务等直接构造执行器的
+    路径）退回文件自身项目的所有权校验。
+
+    Args:
+        session: Database session
+        file: Already-loaded target file
+        user_id: User ID
+
+    Raises:
+        NotFoundError: 文件不属于当前上下文项目（用户可见信息与文件不存在一致）
+        ForbiddenError: 用户不拥有相关项目
+    """
+    # 函数内延迟导入：mcp_tools 在模块加载时经 file_ops 间接导入本模块
+    from agent.tools.mcp_tools import ToolContext
+
+    context_project_id = ToolContext.get_project_id()
+    if context_project_id is None:
+        check_project_ownership(session, file.project_id, user_id)
+        return
+
+    try:
+        check_file_ownership(session, file.id, context_project_id, user_id)
+    except NotFoundError as e:
+        # 与按 id 加载失败共用同一条用户可见文案（真实原因已在权限层日志中）
+        raise NotFoundError("文件不存在或已删除") from e
 
 
 def check_user_exists(

--- a/apps/server/agent/utils/token_utils.py
+++ b/apps/server/agent/utils/token_utils.py
@@ -47,7 +47,7 @@ def _cjk_fraction(text: str) -> float:
         if (
             "一" <= ch <= "鿿"  # CJK Unified Ideographs
             or "㐀" <= ch <= "䶿"  # CJK Extension A
-            or " 0" <= ch <= "⩭f"  # CJK Extension B
+            or "\U00020000" <= ch <= "\U0002A6DF"  # CJK Extension B
             or "　" <= ch <= "〿"  # CJK Symbols and Punctuation
             or "＀" <= ch <= "￯"  # Fullwidth / Halfwidth Forms
         )
@@ -103,8 +103,13 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
 
     Handles various message formats including:
     - Simple string content
-    - List of content blocks (text, thinking, tool_use, image)
+    - List of content blocks (text, tool_use, image)
     - Tool result messages
+
+    Accounting matches what is actually replayed to the model: thinking
+    blocks are persisted for UI/history display only and are dropped before
+    replay (see openai_agents/runner.extract_text_from_message_content),
+    so they contribute 0 tokens here.
 
     Args:
         message: Message dict with role and content
@@ -134,8 +139,6 @@ def estimate_message_tokens(message: dict[str, Any]) -> int:
                     block_type = block.get("type", "")
                     if block_type == "text":
                         total += estimate_text_tokens(block.get("text", ""))
-                    elif block_type == "thinking":
-                        total += estimate_text_tokens(block.get("thinking", ""))
                     elif block_type == "tool_use":
                         name = block.get("name", "")
                         args = block.get("input", {})

--- a/apps/server/api/agent.py
+++ b/apps/server/api/agent.py
@@ -204,6 +204,14 @@ async def stream_request(
                 detail=f"AI conversation quota exceeded ({used}/{limit}). Please upgrade your plan.",
             )
 
+        # SSE 可能持续数分钟，而鉴权/权限校验的 SELECT 会让请求级 session 一直
+        # 保持事务打开（Postgres 上表现为 idle in transaction，连接被整个流式
+        # 期间占用）。此处主动结束事务把连接还回连接池；后续对该 session 的
+        # 使用（如 finally 中的 refund）会惰性开启新事务。rollback 会 expire
+        # ORM 实例，流式期间只能使用已提前取出的标量（user_id），不要再触碰
+        # current_user。
+        session.rollback()
+
         async def event_generator():
             agent_ctx_tokens = bind_request_context(agent_run_id=agent_run_id)
             saw_any_event = False
@@ -279,7 +287,7 @@ async def stream_request(
                         if _should_offload_session_work(session):
                             refund_applied = await asyncio.to_thread(
                                 _release_ai_conversation_sync,
-                                current_user.id,
+                                user_id,
                             )
                         else:
                             # The shared request session may be in a failed
@@ -291,7 +299,7 @@ async def stream_request(
                             # failed internally.
                             with contextlib.suppress(Exception):
                                 session.rollback()
-                            refund_applied = quota_service.release_ai_conversation(session, current_user.id)
+                            refund_applied = quota_service.release_ai_conversation(session, user_id)
                     except Exception as refund_error:
                         log_with_context(
                             logger,

--- a/apps/server/api/chat.py
+++ b/apps/server/api/chat.py
@@ -291,10 +291,12 @@ async def get_session_messages(
             )
         )
         .where(ChatMessage.session_id == chat_session.id)
-        .order_by(ChatMessage.created_at.asc())
+        .order_by(ChatMessage.created_at.desc())
         .limit(limit)
     )
-    messages = session.exec(stmt).all()
+    # 取最近 limit 条再反转为时间升序输出；asc+limit 会永远取最旧的一页，
+    # 导致超过 limit 的会话尾部消息结构性不可达。
+    messages = list(reversed(session.exec(stmt).all()))
 
     log_with_context(
         logger,

--- a/apps/server/services/features/file_version_service.py
+++ b/apps/server/services/features/file_version_service.py
@@ -504,18 +504,13 @@ class FileVersionService:
         lines = content.splitlines(keepends=True)
         result_lines = []
         line_idx = 0
+        in_hunk = False
 
-        i = 0
-        while i < len(diff_lines):
-            line = diff_lines[i]
-
-            # Skip header lines
-            if line.startswith("---") or line.startswith("+++"):
-                i += 1
-                continue
-
-            # Parse hunk header
+        for line in diff_lines:
+            # Parse hunk header (in-hunk content lines always start with
+            # " ", "-" or "+", so "@@" here is unambiguous)
             if line.startswith("@@"):
+                in_hunk = True
                 # Extract line numbers from @@ -start,count +start,count @@
                 match = re.match(r"@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
                 if match:
@@ -525,8 +520,13 @@ class FileVersionService:
                     while line_idx < old_start and line_idx < len(lines):
                         result_lines.append(lines[line_idx])
                         line_idx += 1
+                continue
 
-                i += 1
+            # File headers ("---"/"+++") only appear before the first hunk;
+            # inside a hunk the same prefixes can be real content (e.g. a
+            # removed "---" separator line becomes "----"), so header
+            # skipping must stop once the first hunk starts
+            if not in_hunk:
                 continue
 
             # Process diff content
@@ -546,8 +546,6 @@ class FileVersionService:
                 if line_idx < len(lines):
                     result_lines.append(lines[line_idx])
                     line_idx += 1
-
-            i += 1
 
         # Add remaining lines
         while line_idx < len(lines):

--- a/apps/server/tests/test_agent/test_agent_service_session_id.py
+++ b/apps/server/tests/test_agent/test_agent_service_session_id.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
-from sqlmodel import Session
+from sqlalchemy import create_engine, text
+from sqlmodel import Session, SQLModel, select
 
 from agent.service import AgentService
 from config.datetime_utils import utcnow
@@ -166,3 +167,61 @@ class TestAgentServiceSessionIdResolution:
         assert foreign_row is not None
         assert foreign_row.user_id == user2.id
         assert foreign_row.project_id == project2.id
+
+    def test_reactivates_requested_session_under_partial_unique_index(self, tmp_path):
+        """
+        Postgres enforces uq_chat_session_user_project_active (partial unique on
+        user_id+project_id WHERE is_active). Reactivating a candidate whose
+        primary key sorts BEFORE the currently-active session must not trip the
+        index: the stale deactivation has to reach the DB before the activation.
+        """
+        engine = create_engine(
+            f"sqlite:///{tmp_path / 'partial_unique.db'}",
+            connect_args={"check_same_thread": False},
+        )
+        SQLModel.metadata.create_all(engine)
+        with engine.begin() as conn:
+            # 与 database.py POSTGRES_PERFORMANCE_INDEX_SQL 中的定义保持一致
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX uq_chat_session_user_project_active "
+                    "ON chat_session (user_id, project_id) WHERE is_active = true"
+                )
+            )
+
+        with Session(engine) as session:
+            candidate = ChatSession(
+                id="aaaa-candidate",
+                user_id="user-partial-idx",
+                project_id="proj-partial-idx",
+                title="Old inactive",
+                is_active=False,
+                message_count=0,
+                created_at=utcnow() - timedelta(minutes=10),
+                updated_at=utcnow() - timedelta(minutes=10),
+            )
+            current = ChatSession(
+                id="zzzz-current",
+                user_id="user-partial-idx",
+                project_id="proj-partial-idx",
+                title="Current active",
+                is_active=True,
+                message_count=0,
+            )
+            session.add_all([candidate, current])
+            session.commit()
+
+            service = AgentService(context_assembler=MagicMock())
+            resolved = service._resolve_or_create_chat_session_id(
+                session,
+                project_id="proj-partial-idx",
+                user_id="user-partial-idx",
+                requested_session_id="aaaa-candidate",
+            )
+
+            assert resolved == "aaaa-candidate"
+
+            actives = session.exec(
+                select(ChatSession).where(ChatSession.is_active)
+            ).all()
+            assert [s.id for s in actives] == ["aaaa-candidate"]

--- a/apps/server/tests/test_agent/test_context_prioritizer.py
+++ b/apps/server/tests/test_agent/test_context_prioritizer.py
@@ -49,6 +49,237 @@ def test_classify_priority_handles_lore_and_snippet_thresholds():
     assert prioritizer.classify_priority(strong_snippet) == ContextPriority.RELEVANT
 
 
+def test_classify_priority_upgrades_parent_outline_to_critical():
+    """Parent outlines built via from_outline must reach CRITICAL despite the CONSTRAINT preset."""
+    prioritizer = ContextPrioritizer()
+
+    parent = ContextItem.from_outline(
+        id="outline-parent",
+        title="全书大纲",
+        content="全书故事背景",
+        is_focus=False,
+        relation="parent",
+    )
+
+    assert parent.priority == ContextPriority.CONSTRAINT  # factory preset
+    assert prioritizer.classify_priority(parent) == ContextPriority.CRITICAL
+
+
+def test_classify_priority_never_downgrades_preset_priority():
+    prioritizer = ContextPrioritizer()
+
+    # User-attached outlines get an explicit CRITICAL override in the assembler
+    attached = ContextItem.from_outline(
+        id="outline-attached",
+        title="attached",
+        content="user attached file",
+        is_focus=False,
+        relation="attached",
+    )
+    attached.priority = ContextPriority.CRITICAL
+    assert prioritizer.classify_priority(attached) == ContextPriority.CRITICAL
+
+    # Sibling outlines keep their CONSTRAINT preset
+    sibling = ContextItem.from_outline(
+        id="outline-sibling",
+        title="sibling",
+        content="sibling outline",
+        is_focus=False,
+        relation="sibling",
+    )
+    assert prioritizer.classify_priority(sibling) == ContextPriority.CONSTRAINT
+
+    # Retrieval snippets are pinned to RELEVANT even below the 0.7 threshold
+    snippet = ContextItem.from_snippet(
+        id="snippet-retrieval",
+        title="retrieved",
+        content="snippet",
+        relevance_score=0.55,
+    )
+    snippet.priority = ContextPriority.RELEVANT
+    assert prioritizer.classify_priority(snippet) == ContextPriority.RELEVANT
+
+
+def _cjk(count: int) -> str:
+    return "字" * count
+
+
+def _attached_character(*, id: str = "attached-char", chars: int = 300) -> ContextItem:
+    """用户从聊天框附加的角色文件（assembler 会覆写为 CRITICAL 并打 attached 标记）。"""
+    item = ContextItem.from_character(id=id, name="附加角色", profile=_cjk(chars))
+    item.priority = ContextPriority.CRITICAL
+    item.metadata["attached"] = True
+    return item
+
+
+def _batch(
+    *,
+    focus_chars: int,
+    parent_chars: int,
+    attached: ContextItem | None,
+    characters: int = 10,
+    medium_lore: int = 6,
+    low_lore: int = 4,
+) -> list[ContextItem]:
+    """焦点草稿 + 父大纲 + 可调规模的 CONSTRAINT/RELEVANT/INSPIRATION 需求。"""
+    focus = ContextItem.from_outline(
+        id="focus",
+        title="第10章",
+        content=_cjk(focus_chars),
+        is_focus=True,
+    )
+    focus.metadata["file_type"] = "draft"
+
+    parent = ContextItem.from_outline(
+        id="parent",
+        title="全书大纲",
+        content=_cjk(parent_chars),
+        is_focus=False,
+        relation="parent",
+    )
+    parent.metadata["file_type"] = "outline"
+
+    items = [focus, parent]
+    if attached is not None:
+        items.append(attached)
+    items.extend(
+        ContextItem.from_character(id=f"char-{i}", name=f"角色{i}", profile=_cjk(300))
+        for i in range(characters)
+    )
+    items.extend(
+        ContextItem.from_lore(
+            id=f"lore-med-{i}", title=f"设定{i}", content=_cjk(300), importance="medium"
+        )
+        for i in range(medium_lore)
+    )
+    items.extend(
+        ContextItem.from_lore(
+            id=f"lore-low-{i}", title=f"杂项{i}", content=_cjk(300), importance="low"
+        )
+        for i in range(low_lore)
+    )
+    return items
+
+
+def _select(items: list[ContextItem], max_tokens: int) -> dict[str, ContextItem]:
+    from agent.context.budget import TokenBudget
+
+    prioritizer = ContextPrioritizer()
+    budget = TokenBudget(max_tokens=max_tokens)
+    prioritized = prioritizer.prioritize(items)
+    groups = prioritizer.group_by_priority(prioritized)
+    selected, _ = budget.select_items(prioritized, groups)
+    return {item.id: item for item in selected}
+
+
+def test_parent_outline_upgrade_yields_to_user_attached_content():
+    """有用户附加内容时父大纲留在 CONSTRAINT，避免抢走 CRITICAL 的池化预算。"""
+    prioritizer = ContextPrioritizer()
+
+    with_attached = _batch(
+        focus_chars=1000, parent_chars=600, attached=_attached_character()
+    )
+    groups = prioritizer.group_by_priority(with_attached)
+    critical_ids = [item.id for item in groups[ContextPriority.CRITICAL]]
+    constraint_ids = [item.id for item in groups[ContextPriority.CONSTRAINT]]
+
+    assert critical_ids[:2] == ["focus", "attached-char"]
+    assert "parent" not in critical_ids
+    assert "parent" in constraint_ids
+
+    # 没有附加内容时升级照旧生效（父大纲才能借用低档闲置额度）
+    without_attached = _batch(
+        focus_chars=1000, parent_chars=600, attached=None
+    )
+    groups = prioritizer.group_by_priority(without_attached)
+    assert "parent" in [item.id for item in groups[ContextPriority.CRITICAL]]
+
+
+def test_declined_parent_upgrade_still_never_downgrades():
+    """拒绝升级只退到 CONSTRAINT，不能把条目压到比预设更低的档位。"""
+    prioritizer = ContextPrioritizer()
+    parent = _item(
+        item_type="outline",
+        title="parent",
+        relevance_score=0.8,
+        metadata={"relation": "parent"},
+    )
+    assert parent.priority == ContextPriority.INSPIRATION  # 预设最低档
+
+    groups = prioritizer.group_by_priority([parent, _attached_character()])
+
+    assert [item.title for item in groups[ContextPriority.CONSTRAINT]] == ["parent"]
+    assert groups[ContextPriority.INSPIRATION] == []
+
+
+def test_select_items_keeps_user_attached_file_when_lower_tiers_saturated():
+    """CONSTRAINT/RELEVANT/INSPIRATION 需求饱和时，用户附加的文件仍必须入选。"""
+    attached = _attached_character()
+    items = _batch(focus_chars=1000, parent_chars=600, attached=attached)
+
+    selected = _select(items, max_tokens=5500)
+
+    assert "focus" in selected
+    assert "attached-char" in selected, "用户显式附加的文件被挤出上下文"
+    assert not selected["attached-char"].is_truncated
+    # 父大纲仍在 CONSTRAINT 档保底入选
+    assert "parent" in selected
+
+
+def test_select_items_lets_parent_outline_use_pooled_critical_budget():
+    """无附加内容时，超出 CONSTRAINT 份额的父大纲应完整进入 CRITICAL 池化预算。"""
+    # 低档需求很小 → CRITICAL 可借用闲置额度
+    items = _batch(
+        focus_chars=400,
+        parent_chars=3000,
+        attached=None,
+        characters=2,
+        medium_lore=1,
+        low_lore=0,
+    )
+
+    selected = _select(items, max_tokens=8000)
+
+    assert "parent" in selected
+    assert not selected["parent"].is_truncated
+
+
+def test_group_by_priority_keeps_focus_first_despite_recall_boost():
+    """query recall 加成不得把其他条目排到焦点文件之前。"""
+    prioritizer = ContextPrioritizer()
+    items = _batch(focus_chars=1000, parent_chars=1500, attached=None)
+    for item in items:
+        if item.id == "parent":
+            item.relevance_score = 1.04  # _apply_query_recall_ranking 的加成
+
+    groups = prioritizer.group_by_priority(items)
+
+    assert [item.id for item in groups[ContextPriority.CRITICAL]] == ["focus", "parent"]
+    assert [item.id for item in prioritizer.prioritize(items)][:2] == ["focus", "parent"]
+
+
+def test_group_by_priority_ranks_attached_before_higher_relevance_items():
+    prioritizer = ContextPrioritizer()
+    attached = _attached_character()
+    quote = ContextItem.from_quote(id="quote", text="选中的正文", file_title="第10章")
+    promoted_snippet = ContextItem.from_snippet(
+        id="snippet", title="检索片段", content="内容", relevance_score=0.95
+    )
+    promoted_snippet.priority = ContextPriority.CRITICAL
+    focus = ContextItem.from_outline(
+        id="focus", title="第10章", content="正文", is_focus=True
+    )
+
+    groups = prioritizer.group_by_priority([promoted_snippet, attached, quote, focus])
+
+    assert [item.id for item in groups[ContextPriority.CRITICAL]] == [
+        "focus",
+        "quote",
+        "attached-char",
+        "snippet",
+    ]
+
+
 def test_prioritize_sorts_by_priority_then_relevance_then_type():
     prioritizer = ContextPrioritizer()
     items = [

--- a/apps/server/tests/test_agent/test_cross_project_scope.py
+++ b/apps/server/tests/test_agent/test_cross_project_scope.py
@@ -1,0 +1,341 @@
+"""跨项目文件访问回归测试
+
+edit_file / update_file / delete_file 按 id 定位文件时，必须校验目标文件属于
+当前 ToolContext 绑定的项目：同一用户名下其它项目的文件对会话内工具视同不存在
+（根文件夹 id 形如 "{project_id}-draft-folder" 可预测，仅靠"用户拥有该文件所在
+项目"不足以阻止被注入文本诱导的跨项目写/删）。
+
+覆盖：
+- 生产分发路径（mcp_tools 包装 → FileToolExecutor → FileEditor/FileCRUD）
+- 执行器直连路径（FileToolExecutor 在工具上下文中被直接调用）
+- 错误语义：跨项目访问的用户可见信息与"文件不存在"一致，不泄漏目标项目/文件
+- 未绑定工具上下文时退回文件自身项目的所有权校验（合法的非会话调用不受影响）
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from agent.tools.file_ops import FileToolExecutor
+from agent.tools.mcp_tools import ToolContext, delete_file, edit_file
+from agent.tools.permissions import NotFoundError
+from models import File, Project, User
+
+# ========== Fixtures ==========
+
+
+def _parse_payload(result: dict) -> dict:
+    text = result["content"][0]["text"]
+    return json.loads(text)
+
+
+@pytest.fixture
+def test_user(db_session):
+    """创建测试用户"""
+    from services.core.auth_service import hash_password
+
+    suffix = uuid4().hex[:8]
+    user = User(
+        email=f"cross-project-scope-{suffix}@example.com",
+        username=f"cross_project_scope_{suffix}",
+        hashed_password=hash_password("password123"),
+        name="Cross Project Scope User",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def project_a(db_session, test_user):
+    """当前会话绑定的项目 A"""
+    project = Project(
+        name="Scope Project A",
+        description="Session-bound project",
+        owner_id=test_user.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+    return project
+
+
+@pytest.fixture
+def project_b(db_session, test_user):
+    """同一用户的另一个项目 B（会话外目标）"""
+    project = Project(
+        name="Scope Project B",
+        description="Other project of the same user",
+        owner_id=test_user.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+    return project
+
+
+@pytest.fixture
+def file_a(db_session, project_a):
+    """项目 A 中的草稿"""
+    file = File(
+        project_id=project_a.id,
+        title="A 章节",
+        file_type="draft",
+        content="项目 A 原文",
+    )
+    db_session.add(file)
+    db_session.commit()
+    db_session.refresh(file)
+    return file
+
+
+@pytest.fixture
+def file_b(db_session, project_b):
+    """项目 B 中的草稿"""
+    file = File(
+        project_id=project_b.id,
+        title="B 章节",
+        file_type="draft",
+        content="项目 B 原文",
+    )
+    db_session.add(file)
+    db_session.commit()
+    db_session.refresh(file)
+    return file
+
+
+@pytest.fixture
+def draft_folder_b(db_session, project_b, file_b):
+    """项目 B 的根草稿文件夹（id 可由 project_id 推出）+ 子文件"""
+    folder = File(
+        id=f"{project_b.id}-draft-folder",
+        project_id=project_b.id,
+        title="草稿",
+        file_type="folder",
+        order=0,
+    )
+    db_session.add(folder)
+    db_session.commit()
+    file_b.parent_id = folder.id
+    db_session.add(file_b)
+    db_session.commit()
+    db_session.refresh(folder)
+    return folder
+
+
+# ========== 生产分发路径（mcp_tools 包装） ==========
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_edit_file_rejects_file_from_other_project_of_same_user(
+    db_session, test_user, project_a, project_b, file_b
+):
+    """会话绑定项目 A 时，edit_file 不得改写同一用户项目 B 中的文件"""
+    ToolContext.set_context(
+        session=db_session,
+        user_id=test_user.id,
+        project_id=project_a.id,
+        session_id="sess-scope-edit",
+    )
+    try:
+        result = await edit_file({
+            "id": file_b.id,
+            "edits": [{"op": "append", "text": "注入的内容"}],
+        })
+    finally:
+        ToolContext.clear_context()
+
+    payload = _parse_payload(result)
+    assert payload["status"] == "error"
+    # 用户可见信息与"文件不存在"一致，不泄漏其它项目文件的存在性
+    assert "文件不存在" in payload["error"]
+    assert project_b.id not in payload["error"]
+    assert file_b.id not in payload["error"]
+
+    db_session.expire_all()
+    fresh = db_session.get(File, file_b.id)
+    assert fresh.content == "项目 B 原文"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_delete_file_rejects_predictable_root_folder_of_other_project(
+    db_session, test_user, project_a, project_b, file_b, draft_folder_b
+):
+    """会话绑定项目 A 时，delete_file 不得递归删除项目 B 的草稿文件夹树"""
+    ToolContext.set_context(
+        session=db_session,
+        user_id=test_user.id,
+        project_id=project_a.id,
+        session_id="sess-scope-delete",
+    )
+    try:
+        result = await delete_file({
+            "id": f"{project_b.id}-draft-folder",
+            "recursive": True,
+        })
+    finally:
+        ToolContext.clear_context()
+
+    payload = _parse_payload(result)
+    assert payload["status"] == "error"
+    assert "文件不存在" in payload["error"]
+    assert project_b.id not in payload["error"]
+
+    db_session.expire_all()
+    folder = db_session.get(File, draft_folder_b.id)
+    child = db_session.get(File, file_b.id)
+    assert folder.is_deleted is False
+    assert child.is_deleted is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_edit_file_same_project_still_works(
+    db_session, test_user, project_a, file_a
+):
+    """会话内对当前项目文件的编辑不受影响"""
+    ToolContext.set_context(
+        session=db_session,
+        user_id=test_user.id,
+        project_id=project_a.id,
+        session_id="sess-scope-ok",
+    )
+    try:
+        result = await edit_file({
+            "id": file_a.id,
+            "edits": [{"op": "append", "text": "，续写"}],
+        })
+    finally:
+        ToolContext.clear_context()
+
+    payload = _parse_payload(result)
+    assert payload["status"] == "success"
+
+    db_session.expire_all()
+    fresh = db_session.get(File, file_a.id)
+    assert fresh.content == "项目 A 原文，续写"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_edit_file_requires_project_context():
+    """未绑定项目上下文时写工具直接失败，而不是绕过项目校验"""
+    mock_executor = MagicMock()
+    with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor):
+        result = await edit_file({
+            "id": "file-1",
+            "edits": [{"op": "append", "text": "x"}],
+        })
+
+    payload = _parse_payload(result)
+    assert payload["status"] == "error"
+    assert "project_id not set" in payload["error"]
+    mock_executor.edit_file.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_delete_file_requires_project_context():
+    """未绑定项目上下文时删除工具直接失败，而不是绕过项目校验"""
+    mock_executor = MagicMock()
+    with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor):
+        result = await delete_file({"id": "file-1"})
+
+    payload = _parse_payload(result)
+    assert payload["status"] == "error"
+    assert "project_id not set" in payload["error"]
+    mock_executor.delete_file.assert_not_called()
+
+
+# ========== 执行器直连路径（FileToolExecutor/FileEditor/FileCRUD） ==========
+
+
+@pytest.mark.unit
+def test_executor_edit_file_rejects_cross_project_under_tool_context(
+    db_session, test_user, project_a, project_b, file_b
+):
+    """绕过 mcp_tools 包装、直接调用执行器同样受当前上下文项目约束"""
+    executor = FileToolExecutor(db_session, test_user.id)
+    ToolContext.set_context(
+        session=db_session,
+        user_id=test_user.id,
+        project_id=project_a.id,
+        session_id="sess-scope-exec-edit",
+    )
+    try:
+        with pytest.raises(NotFoundError, match="文件不存在"):
+            executor.edit_file(
+                id=file_b.id,
+                edits=[{"op": "append", "text": "注入"}],
+            )
+    finally:
+        ToolContext.clear_context()
+
+    db_session.expire_all()
+    assert db_session.get(File, file_b.id).content == "项目 B 原文"
+
+
+@pytest.mark.unit
+def test_executor_update_file_rejects_cross_project_under_tool_context(
+    db_session, test_user, project_a, project_b, file_b
+):
+    executor = FileToolExecutor(db_session, test_user.id)
+    ToolContext.set_context(
+        session=db_session,
+        user_id=test_user.id,
+        project_id=project_a.id,
+        session_id="sess-scope-exec-update",
+    )
+    try:
+        with pytest.raises(NotFoundError, match="文件不存在"):
+            executor.update_file(id=file_b.id, content="整体覆盖")
+    finally:
+        ToolContext.clear_context()
+
+    db_session.expire_all()
+    assert db_session.get(File, file_b.id).content == "项目 B 原文"
+
+
+@pytest.mark.unit
+def test_executor_delete_file_rejects_cross_project_under_tool_context(
+    db_session, test_user, project_a, project_b, file_b
+):
+    executor = FileToolExecutor(db_session, test_user.id)
+    ToolContext.set_context(
+        session=db_session,
+        user_id=test_user.id,
+        project_id=project_a.id,
+        session_id="sess-scope-exec-delete",
+    )
+    try:
+        with pytest.raises(NotFoundError, match="文件不存在"):
+            executor.delete_file(id=file_b.id)
+    finally:
+        ToolContext.clear_context()
+
+    db_session.expire_all()
+    assert db_session.get(File, file_b.id).is_deleted is False
+
+
+# ========== 未绑定工具上下文的合法调用不受影响 ==========
+
+
+@pytest.mark.unit
+def test_executor_without_tool_context_falls_back_to_ownership_check(
+    db_session, test_user, project_b, file_b
+):
+    """非会话调用（如 stream_adapter 落盘、后台任务）仍按文件所属项目做所有权校验"""
+    executor = FileToolExecutor(db_session, test_user.id)
+
+    result = executor.update_file(id=file_b.id, content="项目 B 新内容")
+
+    assert result["id"] == file_b.id
+    db_session.expire_all()
+    assert db_session.get(File, file_b.id).content == "项目 B 新内容"

--- a/apps/server/tests/test_agent/test_file_ops_regressions.py
+++ b/apps/server/tests/test_agent/test_file_ops_regressions.py
@@ -1,0 +1,382 @@
+"""
+文件工具回归测试：陈旧读取 / 版本顺序 / replace_all 截断 / query_files 分页
+
+覆盖：
+- edit_file / update_file 在共享 session（SQLite 路径）下必须基于数据库最新内容
+  做 read-modify-write，而不是身份映射里的陈旧快照
+- 并发编辑同一文件时，最高版本号的快照内容必须等于最终 file.content
+- fuzzy 路径 replace_all 不得在 20 处被静默截断
+- query_files 的 limit/offset 作用于多 file_types 合并后的结果集
+"""
+
+import threading
+
+import pytest
+from services.file_version import FileVersionService
+from sqlmodel import Session, select
+
+from agent.tools.file_ops import FileCRUD, FileEditor
+from models import File, Project, User
+from models.file_version import FileVersion
+
+# ========== Fixtures ==========
+
+
+@pytest.fixture
+def test_user(db_session):
+    """创建测试用户"""
+    from services.core.auth_service import hash_password
+
+    user = User(
+        email="file_ops_regressions@example.com",
+        username="file_ops_regressions",
+        hashed_password=hash_password("password123"),
+        name="Regression User",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_project(db_session, test_user):
+    """创建测试项目"""
+    project = Project(
+        name="File Ops Regression Project",
+        description="Regression project for file ops",
+        owner_id=test_user.id,
+    )
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+    return project
+
+
+@pytest.fixture
+def version_engine(db_session, monkeypatch):
+    """让独立版本 session（database.create_session）落到测试库"""
+    import database
+
+    engine = db_session.get_bind()
+    monkeypatch.setattr(database, "create_session", lambda: Session(engine))
+    return engine
+
+
+def _create_file(db_session, project_id: str, title: str, content: str, **kwargs) -> File:
+    file = File(
+        project_id=project_id,
+        title=title,
+        file_type=kwargs.pop("file_type", "draft"),
+        content=content,
+        **kwargs,
+    )
+    db_session.add(file)
+    db_session.commit()
+    db_session.refresh(file)
+    return file
+
+
+# ========== Bug: 共享 session 身份映射陈旧读取 ==========
+
+
+def test_edit_file_reads_latest_content_past_identity_map(
+    db_session, test_user, test_project, version_engine
+):
+    """共享 session 已缓存旧 File；edit_file 必须基于其它 session 提交的最新内容。"""
+    file = _create_file(db_session, test_project.id, "草稿", "旧内容第一版。")
+
+    # 模拟上下文组装阶段：共享 session 把 File 加载进身份映射
+    cached = db_session.get(File, file.id)
+    assert cached.content == "旧内容第一版。"
+
+    # 用户在 LLM 往返期间通过独立 session 自动保存了新内容
+    with Session(version_engine) as other:
+        concurrent = other.get(File, file.id)
+        concurrent.content = "用户自动保存的新内容。"
+        other.add(concurrent)
+        other.commit()
+
+    editor = FileEditor(db_session, user_id=test_user.id)
+    editor.edit_file(file.id, [{"op": "append", "text": "AI追加的段落。"}])
+
+    with Session(version_engine) as check:
+        latest = check.get(File, file.id)
+        assert latest.content == "用户自动保存的新内容。AI追加的段落。"
+
+
+def test_update_file_content_changed_uses_fresh_content(
+    db_session, test_user, test_project, version_engine
+):
+    """update_file 的 content_changed 判定必须基于数据库最新内容而非缓存值。"""
+    file = _create_file(db_session, test_project.id, "设定", "v1")
+
+    cached = db_session.get(File, file.id)
+    assert cached.content == "v1"
+
+    with Session(version_engine) as other:
+        concurrent = other.get(File, file.id)
+        concurrent.content = "v2"
+        other.add(concurrent)
+        other.commit()
+
+    crud = FileCRUD(db_session, user_id=test_user.id)
+    crud.update_file(file.id, content="v1")
+
+    with Session(version_engine) as check:
+        latest = check.get(File, file.id)
+        assert latest.content == "v1"
+        versions = list(
+            check.exec(select(FileVersion).where(FileVersion.file_id == file.id)).all()
+        )
+        assert len(versions) == 1
+
+
+# ========== Bug: 并发编辑时版本链头与正文逆序 ==========
+
+
+def _assert_head_version_matches_content(engine, file_id: str) -> None:
+    with Session(engine) as check:
+        latest_file = check.get(File, file_id)
+        service = FileVersionService()
+        versions = service.get_versions(check, file_id, include_auto_save=True)
+        assert versions, "应当已生成版本快照"
+        head = versions[0]  # newest first
+        head_content = service.get_content_at_version(check, file_id, head.version_number)
+        assert head_content == latest_file.content
+        return latest_file.content
+
+
+def test_concurrent_edit_file_head_version_matches_content(
+    db_session, test_user, test_project, version_engine, monkeypatch
+):
+    """两个并发 edit_file：最高版本号的快照内容必须等于最终 file.content。"""
+    file = _create_file(db_session, test_project.id, "并发草稿", "基础内容。")
+    file_id = file.id
+
+    a_in_version = threading.Event()
+    b_finished = threading.Event()
+    orig_create = FileEditor._create_edit_version
+
+    def paced_version(self, fid, content, applied_edits):
+        if threading.current_thread().name == "editor-a":
+            a_in_version.set()
+            # 给并发编辑留出插队窗口：若该点位于内容 commit 之后且无互斥，
+            # 另一个编辑会先提交内容并先写版本，导致版本链头指向旧内容
+            b_finished.wait(timeout=2.0)
+        orig_create(self, fid, content, applied_edits)
+
+    monkeypatch.setattr(FileEditor, "_create_edit_version", paced_version)
+
+    errors: list[Exception] = []
+
+    def run_edit(text: str):
+        s = Session(version_engine)
+        try:
+            FileEditor(s, user_id=test_user.id).edit_file(
+                file_id, [{"op": "append", "text": text}]
+            )
+        except Exception as e:  # pragma: no cover - 失败时直接暴露
+            errors.append(e)
+        finally:
+            s.close()
+
+    def run_b():
+        a_in_version.wait(timeout=5.0)
+        run_edit("B段。")
+        b_finished.set()
+
+    ta = threading.Thread(target=run_edit, args=("A段。",), name="editor-a")
+    tb = threading.Thread(target=run_b, name="editor-b")
+    ta.start()
+    tb.start()
+    ta.join(timeout=15)
+    tb.join(timeout=15)
+    assert not errors
+
+    final_content = _assert_head_version_matches_content(version_engine, file_id)
+    assert "A段。" in final_content
+    assert "B段。" in final_content
+
+
+def test_concurrent_update_file_head_version_matches_content(
+    db_session, test_user, test_project, version_engine, monkeypatch
+):
+    """两个并发 update_file：最高版本号的快照内容必须等于最终 file.content。"""
+    file = _create_file(db_session, test_project.id, "并发设定", "基础版本。")
+    file_id = file.id
+
+    a_in_version = threading.Event()
+    b_finished = threading.Event()
+    orig_create = FileCRUD._create_version
+
+    def paced_version(self, fid, content, **kwargs):
+        if threading.current_thread().name == "updater-a":
+            a_in_version.set()
+            b_finished.wait(timeout=2.0)
+        orig_create(self, fid, content, **kwargs)
+
+    monkeypatch.setattr(FileCRUD, "_create_version", paced_version)
+
+    errors: list[Exception] = []
+
+    def run_update(text: str):
+        s = Session(version_engine)
+        try:
+            FileCRUD(s, user_id=test_user.id).update_file(file_id, content=text)
+        except Exception as e:  # pragma: no cover - 失败时直接暴露
+            errors.append(e)
+        finally:
+            s.close()
+
+    def run_b():
+        a_in_version.wait(timeout=5.0)
+        run_update("第二版全文。")
+        b_finished.set()
+
+    ta = threading.Thread(target=run_update, args=("第一版全文。",), name="updater-a")
+    tb = threading.Thread(target=run_b, name="updater-b")
+    ta.start()
+    tb.start()
+    ta.join(timeout=15)
+    tb.join(timeout=15)
+    assert not errors
+
+    _assert_head_version_matches_content(version_engine, file_id)
+
+
+# ========== Bug: fuzzy 路径 replace_all 截断 ==========
+
+
+def _build_repeated_content(occurrences: int) -> str:
+    return "\n".join(
+        f"第{i}段：神秘的宝藏，就在这里！其他内容{i}。" for i in range(occurrences)
+    )
+
+
+def test_fuzzy_replace_all_replaces_beyond_20(
+    db_session, test_user, test_project, version_engine
+):
+    """标点差异走 fuzzy 路径时，replace_all 必须替换全部出现而非前 20 处。"""
+    occurrences = 25
+    file = _create_file(
+        db_session, test_project.id, "重复片段", _build_repeated_content(occurrences)
+    )
+
+    editor = FileEditor(db_session, user_id=test_user.id)
+    result = editor.edit_file(
+        file.id,
+        [{
+            "op": "replace",
+            "old": "神秘的宝藏就在这里",  # 无标点 → 精确匹配失败，落入 fuzzy
+            "new": "宝藏已经易主",
+            "replace_all": True,
+        }],
+    )
+
+    detail = result["details"][0]
+    assert detail["match_mode"] == "fuzzy"
+    assert detail["count"] == occurrences
+
+    with Session(version_engine) as check:
+        final = check.get(File, file.id).content
+    assert final.count("宝藏已经易主") == occurrences
+    assert "神秘的宝藏" not in final
+
+
+def test_fuzzy_replace_all_warns_when_cap_hit(
+    db_session, test_user, test_project, version_engine, monkeypatch
+):
+    """达到 replace_all 上限时必须显式告警并标记 truncated。"""
+    import agent.tools.file_ops.edit as edit_module
+
+    monkeypatch.setattr(edit_module, "REPLACE_ALL_MAX_FUZZY_MATCHES", 5)
+
+    occurrences = 8
+    file = _create_file(
+        db_session, test_project.id, "超限片段", _build_repeated_content(occurrences)
+    )
+
+    editor = FileEditor(db_session, user_id=test_user.id)
+    result = editor.edit_file(
+        file.id,
+        [{
+            "op": "replace",
+            "old": "神秘的宝藏就在这里",
+            "new": "宝藏已经易主",
+            "replace_all": True,
+        }],
+    )
+
+    detail = result["details"][0]
+    assert detail["count"] == 5
+    assert detail["truncated"] is True
+    assert any("上限" in w for w in result["warnings"])
+
+
+# ========== Bug: NFKC 展开边界（edit_file 层） ==========
+
+
+def test_edit_replace_rejects_mid_expansion_fuzzy_match(
+    db_session, test_user, test_project, version_engine
+):
+    """pattern 结束于展开字符（Ⅻ→xii）中途时必须拒绝，而非吞掉整个 Ⅻ。"""
+    content = "他们说序章完毕。第Ⅻ章开始了……"
+    file = _create_file(db_session, test_project.id, "罗马数字章节", content)
+
+    editor = FileEditor(db_session, user_id=test_user.id)
+    with pytest.raises(ValueError):
+        editor.edit_file(
+            file.id,
+            [{"op": "replace", "old": "序章完毕第x", "new": "新的开头"}],
+        )
+
+    with Session(version_engine) as check:
+        assert check.get(File, file.id).content == content
+
+    # continue_on_error 模式下应在 warnings 中说明拒绝原因
+    result = editor.edit_file(
+        file.id,
+        [{"op": "replace", "old": "序章完毕第x", "new": "新的开头"}],
+        continue_on_error=True,
+    )
+    assert result["edits_applied"] == 0
+    assert result["failed_edits"]
+    assert any("边界" in w for w in result["warnings"])
+
+
+# ========== Bug: query_files 逐类型分页 ==========
+
+
+@pytest.fixture
+def mixed_type_files(db_session, test_project):
+    """3 个角色 + 3 个设定，order 交错：角色=1/3/5，设定=2/4/6"""
+    for i in range(3):
+        _create_file(
+            db_session, test_project.id, f"角色{i}", f"角色内容{i}",
+            file_type="character", order=2 * i + 1,
+        )
+        _create_file(
+            db_session, test_project.id, f"设定{i}", f"设定内容{i}",
+            file_type="lore", order=2 * i + 2,
+        )
+    return test_project
+
+
+def test_query_files_limit_applies_to_merged_types(db_session, test_user, mixed_type_files):
+    crud = FileCRUD(db_session, user_id=test_user.id)
+    results = crud.query_files(
+        mixed_type_files.id, file_types=["character", "lore"], limit=4
+    )
+    assert len(results) == 4
+    assert [r["title"] for r in results] == ["角色0", "设定0", "角色1", "设定1"]
+
+
+def test_query_files_offset_applies_to_merged_types(db_session, test_user, mixed_type_files):
+    crud = FileCRUD(db_session, user_id=test_user.id)
+    page = crud.query_files(
+        mixed_type_files.id, file_types=["character", "lore"], limit=2, offset=2
+    )
+    assert [r["title"] for r in page] == ["角色1", "设定1"]

--- a/apps/server/tests/test_agent/test_mcp_tools.py
+++ b/apps/server/tests/test_agent/test_mcp_tools.py
@@ -1,5 +1,6 @@
 """Tests for MCP tool wrappers."""
 
+import asyncio
 import json
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -710,7 +711,10 @@ async def test_edit_file_forwards_continue_on_error():
     mock_executor = MagicMock()
     mock_executor.edit_file.return_value = {"id": "f-1", "edits_applied": 1}
 
-    with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor):
+    with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor), patch(
+        "agent.tools.mcp_tools.ToolContext._get_context",
+        return_value={"project_id": "proj-1"},
+    ):
         result = await edit_file({
             "id": "f-1",
             "edits": [{"op": "append", "text": "x"}],
@@ -733,7 +737,10 @@ async def test_edit_file_accepts_file_id_alias():
     mock_executor = MagicMock()
     mock_executor.edit_file.return_value = {"id": "f-1", "edits_applied": 1}
 
-    with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor):
+    with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor), patch(
+        "agent.tools.mcp_tools.ToolContext._get_context",
+        return_value={"project_id": "proj-1"},
+    ):
         result = await edit_file({
             "file_id": "f-1",
             "edits": [{"op": "append", "text": "x"}],
@@ -787,6 +794,9 @@ async def test_tool_result_payload_is_truncated_when_exceeding_limit():
     }
 
     with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor), patch(
+        "agent.tools.mcp_tools.ToolContext._get_context",
+        return_value={"project_id": "proj-1"},
+    ), patch(
         "agent.tools.mcp_tools.TOOL_RESULT_MAX_CHARS",
         180,
     ):
@@ -888,6 +898,9 @@ async def test_tool_error_payload_is_truncated_when_exceeding_limit():
     mock_executor.edit_file.side_effect = ValueError("boom-" + ("x" * 2000))
 
     with patch("agent.tools.mcp_tools.ToolContext.get_executor", return_value=mock_executor), patch(
+        "agent.tools.mcp_tools.ToolContext._get_context",
+        return_value={"project_id": "proj-1"},
+    ), patch(
         "agent.tools.mcp_tools.TOOL_RESULT_MAX_CHARS",
         180,
     ):
@@ -1119,14 +1132,14 @@ async def test_create_empty_file_sets_pending_marker_on_offload_path(db_session)
     """Regression: the pending-empty-file marker must survive the Postgres-style
     offload path.
 
-    _create_file_sync sets the marker via a ContextVar. When create_file offloads
-    it with asyncio.to_thread (production/Postgres), that runs in a COPIED context
-    so the marker is lost in the caller's context — disabling the
-    consecutive-empty-file guard and the writing_graph correction loop. The async
-    wrapper must re-apply it here.
+    When create_file offloads _create_file_sync with asyncio.to_thread
+    (production/Postgres), the sync impl runs in a COPIED context. The marker it
+    sets there must still be visible in the caller's (event-loop) context —
+    otherwise the consecutive-empty-file guard and the writing_graph correction
+    loop are both disabled in production.
     """
     from agent.tools.mcp_tools import ToolContext
-    from models import File, Project, User
+    from models import Project, User
 
     suffix = uuid4().hex[:8]
     user = User(
@@ -1176,6 +1189,214 @@ async def test_create_empty_file_sets_pending_marker_on_offload_path(db_session)
         pending = ToolContext.get_pending_empty_file()
         assert pending is not None
         assert pending["file_id"] == payload["data"]["id"]
+    finally:
+        ToolContext.clear_pending_empty_file()
+        ToolContext.clear_context()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_consecutive_empty_create_file_rejected_across_tool_tasks(db_session):
+    """连续创建第二个空文件必须被拦截 — 即使两次 create_file 分别运行在
+    SDK 为每次工具调用包的独立 asyncio 子任务里。
+
+    第一个空文件的 pending 标记若只存在于子任务的 contextvars 副本中，第二次
+    create_file（另一个子任务）就看不到守卫，stream_adapter 会无条件覆盖捕获
+    目标，第一个文件已流出的正文被静默丢弃。
+    """
+    from agent.tools.mcp_tools import ToolContext
+    from models import Project, User
+
+    suffix = uuid4().hex[:8]
+    user = User(
+        email=f"mcp-guard-{suffix}@example.com",
+        username=f"mcp_guard_{suffix}",
+        hashed_password="hashed",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    project = Project(
+        name=f"MCP Guard Project {suffix}",
+        owner_id=user.id,
+        project_type="novel",
+    )
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+
+    ToolContext.set_context(
+        session=db_session,
+        user_id=user.id,
+        project_id=project.id,
+        session_id="sess-guard",
+    )
+    try:
+        first = await asyncio.create_task(create_file({
+            "title": "第1章",
+            "file_type": "draft",
+            "content": "",
+        }))
+        first_payload = _parse_payload(first)
+        assert first_payload["status"] == "success"
+        # 子任务里设置的标记必须在父上下文可见
+        assert ToolContext.has_pending_empty_file() is True
+
+        second = await asyncio.create_task(create_file({
+            "title": "第2章",
+            "file_type": "draft",
+            "content": "",
+        }))
+        second_payload = _parse_payload(second)
+        assert second_payload["status"] == "error"
+        assert "第1章" in second_payload["error"]
+    finally:
+        ToolContext.clear_pending_empty_file()
+        ToolContext.clear_context()
+
+
+def _make_user_and_project(db_session, tag: str):
+    """建一个可用于 create_file 的真实 user + novel project。"""
+    from models import Project, User
+
+    suffix = uuid4().hex[:8]
+    user = User(
+        email=f"mcp-{tag}-{suffix}@example.com",
+        username=f"mcp_{tag}_{suffix}",
+        hashed_password="hashed",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    project = Project(
+        name=f"MCP {tag} Project {suffix}",
+        owner_id=user.id,
+        project_type="novel",
+    )
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+    return user, project
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_folder_does_not_set_pending_empty_file_marker(db_session):
+    """创建文件夹不得置 pending-empty-file 标记，否则本轮后续建档被永久阻断。
+
+    create_file 的 schema 没有 content 参数（content 恒为 ""），文件夹又永远不会
+    收到 <file>…</file> 正文，所以标记一旦置上就没有清除路径：分卷/分章结构
+    （先建「第一卷」文件夹再在其下建章节）会在第二次 create_file 上直接报错。
+    """
+    from agent.tools.mcp_tools import ToolContext
+
+    user, project = _make_user_and_project(db_session, "folder")
+
+    ToolContext.set_context(
+        session=db_session,
+        user_id=user.id,
+        project_id=project.id,
+        session_id="sess-folder",
+    )
+    try:
+        folder = await asyncio.create_task(create_file({
+            "title": "第一卷",
+            "file_type": "folder",
+        }))
+        folder_payload = _parse_payload(folder)
+        assert folder_payload["status"] == "success"
+        assert folder_payload["data"]["file_type"] == "folder"
+        assert ToolContext.has_pending_empty_file() is False
+
+        chapter = await asyncio.create_task(create_file({
+            "title": "第1章",
+            "file_type": "draft",
+            "parent_id": folder_payload["data"]["id"],
+        }))
+        chapter_payload = _parse_payload(chapter)
+        assert chapter_payload["status"] == "success"
+        assert chapter_payload["data"]["parent_id"] == folder_payload["data"]["id"]
+
+        # 章节（真正等待流式正文的文件）仍然要置标记
+        pending = ToolContext.get_pending_empty_file()
+        assert pending is not None
+        assert pending["file_id"] == chapter_payload["data"]["id"]
+        assert pending["title"] == "第1章"
+    finally:
+        ToolContext.clear_pending_empty_file()
+        ToolContext.clear_context()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_folder_marker_free_on_offload_path(db_session):
+    """Postgres 卸载路径（asyncio.to_thread）同样不得给文件夹置标记。"""
+    from agent.tools.mcp_tools import ToolContext
+
+    user, project = _make_user_and_project(db_session, "folderoff")
+
+    ToolContext.set_context(
+        session=db_session,
+        user_id=user.id,
+        project_id=project.id,
+        session_id="sess-folder-offload",
+    )
+    try:
+        with patch(
+            "agent.tools.mcp_tools._should_offload_tool_execution",
+            return_value=True,
+        ):
+            folder = await create_file({
+                "title": "第二卷",
+                "file_type": "folder",
+            })
+        assert _parse_payload(folder)["status"] == "success"
+        assert ToolContext.has_pending_empty_file() is False
+    finally:
+        ToolContext.clear_pending_empty_file()
+        ToolContext.clear_context()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_folder_still_blocked_while_file_awaits_content(db_session):
+    """已有待写入正文的文件时，建文件夹仍被拦截（保留防内容丢失的守卫）。
+
+    stream_adapter 会把最近一次 create_file 的返回无条件设为流式捕获目标，
+    因此在正文写完前插入任何 create_file（含文件夹）都会让前一个文件的正文写错
+    位置；这里的拦截是可恢复的：写完正文后标记清除，建文件夹即可继续。
+    """
+    from agent.tools.mcp_tools import ToolContext
+
+    user, project = _make_user_and_project(db_session, "folderguard")
+
+    ToolContext.set_context(
+        session=db_session,
+        user_id=user.id,
+        project_id=project.id,
+        session_id="sess-folder-guard",
+    )
+    try:
+        chapter = await create_file({"title": "第1章", "file_type": "draft"})
+        assert _parse_payload(chapter)["status"] == "success"
+        assert ToolContext.has_pending_empty_file() is True
+
+        blocked = await create_file({"title": "第一卷", "file_type": "folder"})
+        blocked_payload = _parse_payload(blocked)
+        assert blocked_payload["status"] == "error"
+        assert "第1章" in blocked_payload["error"]
+
+        # 正文写入后（stream_adapter 清除标记）文件夹可以正常创建
+        ToolContext.clear_pending_empty_file()
+        folder = await create_file({"title": "第一卷", "file_type": "folder"})
+        assert _parse_payload(folder)["status"] == "success"
+        assert ToolContext.has_pending_empty_file() is False
     finally:
         ToolContext.clear_pending_empty_file()
         ToolContext.clear_context()

--- a/apps/server/tests/test_agent/test_openai_agents_adapter.py
+++ b/apps/server/tests/test_agent/test_openai_agents_adapter.py
@@ -172,6 +172,83 @@ async def test_runner_maps_sdk_text_tool_handoff_and_message_end():
     assert state["messages"][-2]["content"][0]["text"] == "正文"
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_runner_consumes_steering_at_tool_output_boundary():
+    """SDK run 进行中无法注入消息，工具输出边界必须消费 steering：
+    向前端发确认事件，并把内容作为用户消息写回 state 供下一次迭代使用。"""
+    from agent.core.workflow_events import StreamEventType
+    from agent.openai_agents.runner import run_openai_agents_streaming_agent
+
+    class FakeResult:
+        raw_responses = []
+
+        async def stream_events(self):
+            yield SimpleNamespace(
+                type="run_item_stream_event",
+                name="tool_called",
+                item=SimpleNamespace(
+                    raw_item={
+                        "name": "query_files",
+                        "call_id": "call-1",
+                        "arguments": json.dumps({"query": "第一章"}, ensure_ascii=False),
+                    }
+                ),
+            )
+            yield SimpleNamespace(
+                type="run_item_stream_event",
+                name="tool_output",
+                item=SimpleNamespace(
+                    raw_item={"call_id": "call-1"},
+                    output=json.dumps({"status": "success", "data": []}, ensure_ascii=False),
+                ),
+            )
+            yield SimpleNamespace(
+                type="raw_response_event",
+                data=SimpleNamespace(type="response.output_text.delta", delta="正文"),
+            )
+
+    steering_calls = {"n": 0}
+
+    async def fake_get_steering_messages():
+        steering_calls["n"] += 1
+        # 第 1 次：run 开始前的初始注入（队列为空）；
+        # 第 2 次：工具输出边界（用户在生成期间发来了引导）。
+        if steering_calls["n"] == 2:
+            return [{"id": "steer-1", "content": "改成第一人称"}]
+        return []
+
+    state = {"user_message": "写一章", "messages": [], "system_prompt": "base"}
+
+    with (
+        patch("agent.openai_agents.runner._build_agent", return_value=object()),
+        patch("agents.Runner.run_streamed", return_value=FakeResult()),
+    ):
+        events = [
+            event
+            async for event in run_openai_agents_streaming_agent(
+                state=state,
+                agent_type="writer",
+                system_prompt="system",
+                get_steering_messages=fake_get_steering_messages,
+            )
+        ]
+
+    assert steering_calls["n"] >= 2, "工具输出边界必须轮询 steering 队列"
+
+    type_values = [getattr(event.type, "value", "") for event in events]
+    message_start_idx = type_values.index(StreamEventType.MESSAGE_START.value)
+    steering_indexes = [
+        idx for idx, value in enumerate(type_values) if value == "steering_received"
+    ]
+    assert steering_indexes, "消费到的 steering 必须向前端发确认事件"
+    assert all(idx > message_start_idx for idx in steering_indexes)
+    assert events[steering_indexes[0]].data["preview"] == "改成第一人称"
+
+    # run 结束后引导内容进入会话消息，供 graph 的下一次迭代注入模型
+    assert state["messages"][-1] == {"role": "user", "content": "改成第一人称"}
+
+
 def _wait_until_serving(host: str, port: int, timeout: float = 5.0) -> None:
     """Block until the local server accepts a TCP connection (or timeout)."""
     deadline = time.monotonic() + timeout

--- a/apps/server/tests/test_agent/test_parallel_executor.py
+++ b/apps/server/tests/test_agent/test_parallel_executor.py
@@ -360,6 +360,42 @@ class TestExecuteParallel:
         finally:
             ToolContext.clear_context()
 
+    async def test_pending_flag_set_inside_subtask_visible_after_execution(self):
+        """write_chapter 子任务里设置的空文件标记，并行执行结束后主上下文必须可见。
+
+        execute_parallel 用 asyncio.gather 在独立 Task 里执行子任务并为每个
+        子任务重绑定 _tool_context_var；标记若随子任务上下文销毁，writing_graph
+        的纠偏循环与后续 create_file 守卫都读不到它。
+        """
+        from agent.tools.mcp_tools import ToolContext
+
+        ToolContext.set_context(None, "user1", "proj-1", "sess-1")
+        try:
+
+            async def fake_write_chapter(params):
+                # 模拟 create_file 创建空文件后设置 pending 标记
+                ToolContext.set_pending_empty_file("file-z", params.get("title", ""))
+                return _make_result({"status": "success", "data": {"id": "file-z"}})
+
+            with patch(
+                "agent.tools.parallel_executor.handle_write_chapter",
+                new=fake_write_chapter,
+            ):
+                result = await execute_parallel([
+                    {"type": "write_chapter", "description": "W", "params": {"title": "第3章"}},
+                ])
+
+            text = result["content"][0]["text"]
+            parsed = json.loads(text)
+            assert parsed["data"]["all_completed"] is True
+
+            assert ToolContext.has_pending_empty_file() is True
+            pending = ToolContext.get_pending_empty_file()
+            assert pending is not None
+            assert pending["file_id"] == "file-z"
+        finally:
+            ToolContext.clear_context()
+
     async def test_execute_unknown_task_type(self):
         """Test execution with unknown task type."""
         from agent.tools.mcp_tools import ToolContext

--- a/apps/server/tests/test_agent/test_service.py
+++ b/apps/server/tests/test_agent/test_service.py
@@ -9,6 +9,7 @@ Updated for LangGraph architecture.
 
 import asyncio
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -907,9 +908,468 @@ class TestAgentServiceProcessStream:
                 await task
 
         mock_cleanup.assert_not_awaited()
-        assert mock_schedule_cleanup.call_count == 1
-        _args, kwargs = mock_schedule_cleanup.call_args
-        assert kwargs["description"] == "cleanup_steering_queue_async"
+        descriptions = [
+            kwargs["description"] for _args, kwargs in mock_schedule_cleanup.call_args_list
+        ]
+        assert "cleanup_steering_queue_async" in descriptions
+        # Cancellation also schedules the partial-history save in the background.
+        assert "save_partial_history_after_cancellation" in descriptions
+
+    async def test_process_stream_persists_partial_history_on_cancellation(
+        self, mock_agent_service, test_user_with_project, db_session: Session
+    ):
+        """Cancellation must still persist the user message + partial assistant reply."""
+        from agent.core.workflow_events import StreamEvent, StreamEventType
+
+        service, _ = mock_agent_service
+        project = test_user_with_project["project"]
+        user = test_user_with_project["user"]
+
+        started = asyncio.Event()
+
+        async def mock_slow_stream():
+            yield StreamEvent(type=StreamEventType.TEXT, data={"text": "partial reply"})
+            started.set()
+            await asyncio.sleep(3600)
+
+        events: list[str] = []
+
+        async def consume():
+            async for event in service.process_stream(
+                project_id=str(project.id),
+                user_id=str(user.id),
+                message="cancel me please",
+                session=db_session,
+            ):
+                events.append(event)
+
+        def _fresh_session():
+            return Session(db_session.get_bind())
+
+        with (
+            patch("agent.service.run_writing_workflow_streaming", return_value=mock_slow_stream()),
+            patch("agent.service.create_session", side_effect=_fresh_session),
+        ):
+            task = asyncio.create_task(consume())
+            await started.wait()
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            session_started_events = [e for e in events if "event: session_started" in e]
+            assert session_started_events, "Expected session_started event"
+            session_id = json.loads(
+                session_started_events[0].split("data:", 1)[1].strip()
+            )["session_id"]
+
+            # The save runs as a background task with an independent session;
+            # poll until it lands (rollback releases this session's read txn).
+            saved_messages: list[ChatMessage] = []
+            for _ in range(100):
+                await asyncio.sleep(0.05)
+                db_session.rollback()
+                saved_messages = db_session.exec(
+                    select(ChatMessage).where(ChatMessage.session_id == session_id)
+                ).all()
+                if len(saved_messages) >= 2:
+                    break
+
+        assert len(saved_messages) == 2
+        assert any(
+            m.role == "user" and m.content == "cancel me please" for m in saved_messages
+        )
+        assert any(
+            m.role == "assistant" and m.content == "partial reply" for m in saved_messages
+        )
+
+    async def test_process_stream_prompt_ledger_counts_embedded_sections_once(
+        self, mock_agent_service, test_user_with_project, db_session: Session
+    ):
+        """reserved_prompt_tokens must charge the final system prompt exactly once."""
+        from agent.context.budget import compute_history_token_budget as real_compute
+        from agent.core.workflow_events import StreamEvent, StreamEventType
+        from agent.schemas.context import ContextData
+        from agent.utils.token_utils import estimate_text_tokens
+        from config.agent_runtime import AGENT_CHAT_HISTORY_TOKEN_BUDGET
+
+        service, mock_context_assembler = mock_agent_service
+        project = test_user_with_project["project"]
+        user = test_user_with_project["user"]
+
+        assembled_context = "主角在北境雪原遇到了会说话的狐狸。" * 200
+        mock_context_assembler.assemble.return_value = ContextData(
+            items=[],
+            context=assembled_context,
+            token_estimate=estimate_text_tokens(assembled_context),
+        )
+
+        captured: dict[str, int] = {}
+
+        def fake_compute(*, configured_history_budget, reserved_prompt_tokens):
+            captured["reserved"] = reserved_prompt_tokens
+            result = real_compute(
+                configured_history_budget=configured_history_budget,
+                reserved_prompt_tokens=reserved_prompt_tokens,
+            )
+            captured["effective"] = result
+            return result
+
+        async def mock_stream():
+            yield StreamEvent(type=StreamEventType.TEXT, data={"text": "ok"})
+            yield StreamEvent(type=StreamEventType.MESSAGE_END, data={"stop_reason": "end_turn"})
+
+        with (
+            patch("agent.service.run_writing_workflow_streaming") as mock_workflow,
+            patch("agent.service.compute_history_token_budget", side_effect=fake_compute),
+        ):
+            mock_workflow.return_value = mock_stream()
+
+            async for _ in service.process_stream(
+                project_id=str(project.id),
+                user_id=str(user.id),
+                message="预算测试",
+                session=db_session,
+            ):
+                pass
+
+        writing_state = mock_workflow.call_args[0][0]
+        system_prompt = writing_state["system_prompt"]
+        assert assembled_context[:200] in system_prompt  # context 确实内嵌于 system_prompt
+
+        # Ledger charges the final prompt once — no re-adding of skill
+        # catalog/reference/context that build_system_prompt already embedded.
+        assert captured["reserved"] == estimate_text_tokens(system_prompt)
+
+        legacy_reserved = captured["reserved"] + estimate_text_tokens(assembled_context)
+        assert captured["reserved"] < legacy_reserved
+        assert captured["effective"] == real_compute(
+            configured_history_budget=AGENT_CHAT_HISTORY_TOKEN_BUDGET,
+            reserved_prompt_tokens=captured["reserved"],
+        )
+        assert captured["effective"] >= real_compute(
+            configured_history_budget=AGENT_CHAT_HISTORY_TOKEN_BUDGET,
+            reserved_prompt_tokens=legacy_reserved,
+        )
+
+    async def test_process_stream_persists_unconsumed_steering_before_cleanup(
+        self, mock_agent_service, test_user_with_project, db_session: Session
+    ):
+        """流结束时队列里仍未消费的 steering 必须随本轮历史落库，
+        不能被 cleanup 静默删除（POST /steer 已经向用户确认 queued）。"""
+        from agent.core.workflow_events import StreamEvent, StreamEventType
+
+        service, _ = mock_agent_service
+        project = test_user_with_project["project"]
+        user = test_user_with_project["user"]
+
+        def fake_workflow(writing_state, **_kwargs):
+            async def _stream():
+                # 模拟用户在生成期间通过 POST /agent/steer 入队，而工作流
+                # 全程没有任何消费点取走它（单迭代 quick 工作流的真实形态）
+                from agent.core.steering import get_steering_queue_for_user_async
+
+                queue = await get_steering_queue_for_user_async(
+                    writing_state["session_id"], str(user.id)
+                )
+                await queue.add("生成中途的引导：改成第一人称")
+                yield StreamEvent(type=StreamEventType.TEXT, data={"text": "正文"})
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_END, data={"stop_reason": "end_turn"}
+                )
+
+            return _stream()
+
+        with patch(
+            "agent.service.run_writing_workflow_streaming", side_effect=fake_workflow
+        ):
+            events: list[str] = []
+            async for event in service.process_stream(
+                project_id=str(project.id),
+                user_id=str(user.id),
+                message="写一段",
+                session=db_session,
+            ):
+                events.append(event)
+
+        session_started_events = [e for e in events if "event: session_started" in e]
+        assert session_started_events, "Expected session_started event"
+        session_id = json.loads(
+            session_started_events[0].split("data:", 1)[1].strip()
+        )["session_id"]
+
+        db_session.rollback()
+        persisted = db_session.exec(
+            select(ChatMessage).where(ChatMessage.session_id == session_id)
+        ).all()
+        assert any(
+            m.role == "user" and m.content == "生成中途的引导：改成第一人称"
+            for m in persisted
+        ), "未消费的 steering 消息必须持久化为用户消息"
+
+    async def test_process_stream_cancellation_persists_queued_steering(
+        self, mock_agent_service, test_user_with_project, db_session: Session
+    ):
+        """取消路径同样不能丢弃已入队未消费的 steering：后台保存任务先 drain
+        队列再落库，cleanup 在保存完成后才删除队列。"""
+        from agent.core.workflow_events import StreamEvent, StreamEventType
+
+        service, _ = mock_agent_service
+        project = test_user_with_project["project"]
+        user = test_user_with_project["user"]
+
+        started = asyncio.Event()
+
+        def fake_workflow(writing_state, **_kwargs):
+            async def _stream():
+                from agent.core.steering import get_steering_queue_for_user_async
+
+                queue = await get_steering_queue_for_user_async(
+                    writing_state["session_id"], str(user.id)
+                )
+                await queue.add("取消前入队的引导")
+                yield StreamEvent(type=StreamEventType.TEXT, data={"text": "部分内容"})
+                started.set()
+                await asyncio.sleep(3600)
+
+            return _stream()
+
+        events: list[str] = []
+
+        async def consume():
+            async for event in service.process_stream(
+                project_id=str(project.id),
+                user_id=str(user.id),
+                message="取消我",
+                session=db_session,
+            ):
+                events.append(event)
+
+        def _fresh_session():
+            return Session(db_session.get_bind())
+
+        with (
+            patch("agent.service.run_writing_workflow_streaming", side_effect=fake_workflow),
+            patch("agent.service.create_session", side_effect=_fresh_session),
+        ):
+            task = asyncio.create_task(consume())
+            await started.wait()
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            session_started_events = [e for e in events if "event: session_started" in e]
+            assert session_started_events, "Expected session_started event"
+            session_id = json.loads(
+                session_started_events[0].split("data:", 1)[1].strip()
+            )["session_id"]
+
+            steering_rows: list[ChatMessage] = []
+            for _ in range(100):
+                await asyncio.sleep(0.05)
+                db_session.rollback()
+                steering_rows = [
+                    m
+                    for m in db_session.exec(
+                        select(ChatMessage).where(ChatMessage.session_id == session_id)
+                    ).all()
+                    if m.role == "user" and m.content == "取消前入队的引导"
+                ]
+                if steering_rows:
+                    break
+
+        assert steering_rows, "取消时已入队未消费的 steering 必须先落库再清理队列"
+
+    async def test_cancellation_during_history_save_does_not_duplicate_history(
+        self, mock_agent_service, test_user_with_project, db_session: Session
+    ):
+        """取消恰好落在 save_messages 的工作线程期间：线程照样提交完整历史，
+        补偿保存必须等它的真实结果，不能把同一轮再写一遍。"""
+        from agent.core.message_manager import MessageManager
+        from agent.core.workflow_events import StreamEvent, StreamEventType
+
+        service, _ = mock_agent_service
+        project = test_user_with_project["project"]
+        user = test_user_with_project["user"]
+
+        bind = db_session.get_bind()
+        worker_started = threading.Event()
+        allow_commit = threading.Event()
+        real_save_with_session = MessageManager._save_messages_with_session
+
+        async def mock_stream():
+            yield StreamEvent(type=StreamEventType.TEXT, data={"text": "完整回复"})
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_END, data={"stop_reason": "end_turn"}
+            )
+
+        async def fake_save_messages(self, session, *args, **kwargs):
+            # 复刻 PG 路径：save_messages 走 asyncio.to_thread，工作线程一旦
+            # 启动就无法取消，awaiting 侧抛 CancelledError 也照样提交。
+            def _commit_in_worker():
+                worker_started.set()
+                allow_commit.wait(5)
+                with Session(bind) as worker_session:
+                    return real_save_with_session(self, worker_session, *args, **kwargs)
+
+            return await asyncio.to_thread(_commit_in_worker)
+
+        events: list[str] = []
+
+        async def consume():
+            async for event in service.process_stream(
+                project_id=str(project.id),
+                user_id=str(user.id),
+                message="保存中途取消",
+                session=db_session,
+            ):
+                events.append(event)
+
+        scheduled: list[asyncio.Task] = []
+        real_schedule = service._schedule_background_cleanup
+
+        def _tracking_schedule(coro, **kwargs):
+            task = real_schedule(coro, **kwargs)
+            scheduled.append(task)
+            return task
+
+        with (
+            patch("agent.service.run_writing_workflow_streaming", return_value=mock_stream()),
+            patch("agent.service.create_session", side_effect=lambda: Session(bind)),
+            patch.object(MessageManager, "save_messages", new=fake_save_messages),
+            patch.object(
+                service, "_schedule_background_cleanup", side_effect=_tracking_schedule
+            ),
+        ):
+            task = asyncio.create_task(consume())
+            for _ in range(500):
+                if worker_started.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert worker_started.is_set(), "落库工作线程未启动，测试前置条件不成立"
+
+            task.cancel()
+            allow_commit.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            # 等所有后台任务（补偿保存 + 队列清理）跑完再断言，避免竞态假绿
+            if scheduled:
+                await asyncio.gather(*scheduled, return_exceptions=True)
+
+            session_started_events = [e for e in events if "event: session_started" in e]
+            assert session_started_events, "Expected session_started event"
+            session_id = json.loads(
+                session_started_events[0].split("data:", 1)[1].strip()
+            )["session_id"]
+
+            db_session.rollback()
+            persisted = db_session.exec(
+                select(ChatMessage).where(ChatMessage.session_id == session_id)
+            ).all()
+
+        user_rows = [m for m in persisted if m.role == "user"]
+        assistant_rows = [m for m in persisted if m.role == "assistant"]
+        assert len(user_rows) == 1, (
+            f"整轮历史必须恰好落库一次（不重复、不丢失）: {[m.content for m in user_rows]}"
+        )
+        assert len(assistant_rows) == 1, "assistant 消息必须恰好落库一次"
+        assert assistant_rows[0].content == "完整回复"
+
+        chat_session = db_session.get(ChatSession, session_id)
+        assert chat_session is not None
+        assert chat_session.message_count == 2, "message_count 被重复累加"
+
+    async def test_cancellation_falls_back_to_partial_save_when_history_save_fails(
+        self, mock_agent_service, test_user_with_project, db_session: Session
+    ):
+        """落库任务自身失败时，取消路径仍要补偿保存，不能因为「已尝试保存」就丢历史。"""
+        from agent.core.message_manager import MessageManager
+        from agent.core.workflow_events import StreamEvent, StreamEventType
+
+        service, _ = mock_agent_service
+        project = test_user_with_project["project"]
+        user = test_user_with_project["user"]
+
+        bind = db_session.get_bind()
+        worker_started = threading.Event()
+        allow_fail = threading.Event()
+
+        async def mock_stream():
+            yield StreamEvent(type=StreamEventType.TEXT, data={"text": "部分回复"})
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_END, data={"stop_reason": "end_turn"}
+            )
+
+        async def failing_save_messages(self, session, *args, **kwargs):
+            def _fail_in_worker():
+                worker_started.set()
+                allow_fail.wait(5)
+                raise RuntimeError("db unavailable")
+
+            return await asyncio.to_thread(_fail_in_worker)
+
+        events: list[str] = []
+
+        async def consume():
+            async for event in service.process_stream(
+                project_id=str(project.id),
+                user_id=str(user.id),
+                message="落库失败后取消",
+                session=db_session,
+            ):
+                events.append(event)
+
+        scheduled: list[asyncio.Task] = []
+        real_schedule = service._schedule_background_cleanup
+
+        def _tracking_schedule(coro, **kwargs):
+            task = real_schedule(coro, **kwargs)
+            scheduled.append(task)
+            return task
+
+        with (
+            patch("agent.service.run_writing_workflow_streaming", return_value=mock_stream()),
+            patch("agent.service.create_session", side_effect=lambda: Session(bind)),
+            patch.object(MessageManager, "save_messages", new=failing_save_messages),
+            patch.object(
+                service, "_schedule_background_cleanup", side_effect=_tracking_schedule
+            ),
+        ):
+            task = asyncio.create_task(consume())
+            for _ in range(500):
+                if worker_started.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert worker_started.is_set(), "落库工作线程未启动，测试前置条件不成立"
+
+            task.cancel()
+            allow_fail.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            if scheduled:
+                await asyncio.gather(*scheduled, return_exceptions=True)
+
+            session_started_events = [e for e in events if "event: session_started" in e]
+            assert session_started_events, "Expected session_started event"
+            session_id = json.loads(
+                session_started_events[0].split("data:", 1)[1].strip()
+            )["session_id"]
+
+            db_session.rollback()
+            persisted = db_session.exec(
+                select(ChatMessage).where(ChatMessage.session_id == session_id)
+            ).all()
+
+        assert any(
+            m.role == "user" and m.content == "落库失败后取消" for m in persisted
+        ), "落库失败 + 取消时必须补偿保存用户消息"
+        assert any(
+            m.role == "assistant" and m.content == "部分回复" for m in persisted
+        ), "落库失败 + 取消时必须补偿保存已生成内容"
+
 
 @pytest.mark.unit
 class TestAgentServiceHelpers:

--- a/apps/server/tests/test_agent/test_session_loader.py
+++ b/apps/server/tests/test_agent/test_session_loader.py
@@ -148,6 +148,42 @@ class TestSessionLoaderHistoryBudget:
         assert assistant_content[0] == {"type": "thinking", "thinking": "kept reasoning"}
         assert assistant_content[1] == {"type": "text", "text": "m4" * 8}
 
+    def test_history_window_budget_ignores_ui_only_reasoning_content(
+        self,
+        db_session: Session,
+        session_loader_test_data,
+        monkeypatch,
+    ):
+        """Reasoning is dropped before replay, so it must not eat the history window."""
+        monkeypatch.setattr("agent.core.session_loader.AGENT_CHAT_HISTORY_TOKEN_BUDGET", 60)
+        heavy_reasoning = "推理" * 800  # 单条即远超整个预算
+        _add_chat_messages(
+            db_session,
+            session_loader_test_data["chat_session"].id,
+            [
+                {"role": "user", "content": "写下一章"},
+                {"role": "assistant", "content": "好的", "reasoning_content": heavy_reasoning},
+                {"role": "user", "content": "继续"},
+                {"role": "assistant", "content": "收到", "reasoning_content": heavy_reasoning},
+            ],
+        )
+
+        loader = SessionLoader(
+            project_id=session_loader_test_data["project"].id,
+            user_id=session_loader_test_data["user"].id,
+        )
+        session_data = loader.load_chat_session(db_session)
+
+        # 正文 token 很小，四条消息都应留在窗口内
+        assert len(session_data.history_messages) == 4
+        assert session_data.history_messages[0]["content"] == "写下一章"
+
+        # thinking 块仍保留在内容里供 UI/历史使用
+        last_content = session_data.history_messages[-1]["content"]
+        assert isinstance(last_content, list)
+        assert last_content[0] == {"type": "thinking", "thinking": heavy_reasoning}
+        assert last_content[1] == {"type": "text", "text": "收到"}
+
     def test_load_chat_session_returns_empty_history_for_no_messages(
         self,
         db_session: Session,

--- a/apps/server/tests/test_agent/test_steering.py
+++ b/apps/server/tests/test_agent/test_steering.py
@@ -448,3 +448,60 @@ class TestSteeringIntegration:
                 await create_steering_queue_async(session_id, "intruder-user")
         finally:
             await cleanup_steering_queue_async(session_id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSteeringRunOwnership:
+    """并发 stream run 共享同一 session 队列时的 run 级归属（内存路径）。"""
+
+    async def test_first_finishing_run_does_not_delete_other_runs_queue(self):
+        """先结束的 run 只释放自己的持有，另一个 run 的队列必须继续可用。"""
+        session_id = "run-ownership-session"
+        await cleanup_steering_queue_async(session_id)
+
+        try:
+            await create_steering_queue_async(session_id, "user-1", run_id="run-a")
+            await create_steering_queue_async(session_id, "user-1", run_id="run-b")
+
+            queue = await get_steering_queue_for_user_async(session_id, "user-1")
+            await queue.add("run B 还在跑，别删我的消息")
+
+            # run A 先结束：队列仍被 run B 持有，不能删除
+            await cleanup_steering_queue_async(session_id, run_id="run-a")
+
+            surviving = await get_steering_queue_for_user_async(session_id, "user-1")
+            pending = await surviving.peek()
+            assert [m.content for m in pending] == ["run B 还在跑，别删我的消息"]
+
+            # 最后一个持有者退出后才真正删除
+            await cleanup_steering_queue_async(session_id, run_id="run-b")
+            with pytest.raises(KeyError):
+                await get_steering_queue_for_user_async(session_id, "user-1")
+        finally:
+            await cleanup_steering_queue_async(session_id)
+
+    async def test_cleanup_without_run_id_removes_queue_unconditionally(self):
+        """不带 run_id 的 cleanup 保持旧语义：无条件删除。"""
+        session_id = "run-ownership-legacy-cleanup"
+        await cleanup_steering_queue_async(session_id)
+
+        await create_steering_queue_async(session_id, "user-1", run_id="run-a")
+        await cleanup_steering_queue_async(session_id)
+
+        with pytest.raises(KeyError):
+            await get_steering_queue_for_user_async(session_id, "user-1")
+
+    async def test_cleanup_unknown_run_id_keeps_active_holders(self):
+        """释放一个从未注册的 run_id 不应删除仍被持有的队列。"""
+        session_id = "run-ownership-unknown-run"
+        await cleanup_steering_queue_async(session_id)
+
+        try:
+            await create_steering_queue_async(session_id, "user-1", run_id="run-a")
+            await cleanup_steering_queue_async(session_id, run_id="run-zombie")
+
+            queue = await get_steering_queue_for_user_async(session_id, "user-1")
+            assert isinstance(queue, SteeringQueue)
+        finally:
+            await cleanup_steering_queue_async(session_id)

--- a/apps/server/tests/test_agent/test_steering_redis.py
+++ b/apps/server/tests/test_agent/test_steering_redis.py
@@ -5,46 +5,86 @@ is a different process from the one running the SSE stream. With the in-memory
 queue that lookup misses (404 "对话会话不存在"); with Redis both workers share state.
 """
 
+import asyncio
+import threading
+from collections.abc import Callable
+
 import pytest
 
 
 class FakePipeline:
+    """MULTI/EXEC 语义：排队的命令在 execute() 内作为一个原子单元执行，
+    执行期间不会被其它 "worker" 线程的命令插入（与真实 Redis 一致）。"""
+
     def __init__(self, client):
         self.client = client
-        self.ops: list[tuple[str, tuple]] = []
+        self.ops: list[tuple[str, tuple, dict]] = []
 
-    def rpush(self, *args):
-        self.ops.append(("rpush", args))
+    def _queue(self, name, args, kwargs):
+        self.ops.append((name, args, kwargs))
         return self
 
-    def lrange(self, *args):
-        self.ops.append(("lrange", args))
-        return self
+    def rpush(self, *args, **kwargs):
+        return self._queue("rpush", args, kwargs)
 
-    def delete(self, *args):
-        self.ops.append(("delete", args))
-        return self
+    def lrange(self, *args, **kwargs):
+        return self._queue("lrange", args, kwargs)
 
-    def expire(self, *args):
-        self.ops.append(("expire", args))
-        return self
+    def delete(self, *args, **kwargs):
+        return self._queue("delete", args, kwargs)
+
+    def expire(self, *args, **kwargs):
+        return self._queue("expire", args, kwargs)
+
+    def set(self, *args, **kwargs):
+        return self._queue("set", args, kwargs)
+
+    def sadd(self, *args, **kwargs):
+        return self._queue("sadd", args, kwargs)
 
     def execute(self):
-        results = [getattr(self.client, name)(*args) for name, args in self.ops]
-        self.ops = []
-        return results
+        ops, self.ops = self.ops, []
+        return self.client._atomic(
+            "exec",
+            lambda: [
+                getattr(self.client, f"_{name}")(*args, **kwargs)
+                for name, args, kwargs in ops
+            ],
+        )
 
 
 class FakeRedis:
-    """Minimal in-process Redis stand-in shared across "workers" in a test."""
+    """Minimal in-process Redis stand-in shared across "workers" in a test.
+
+    所有状态命令都经过 `_atomic()`：单条命令 / EVAL / MULTI-EXEC 各自持锁执行，
+    模拟真实 Redis 的单线程串行语义；锁释放后再触发 `on_atomic` 钩子，测试可以
+    借此在「两次 round-trip 之间」精确插入另一个客户端的命令序列。
+    """
 
     def __init__(self):
         self.store: dict = {}
+        self._lock = threading.RLock()
+        # 每个原子单元执行完毕（且已释放锁）后回调，参数为单元名。
+        self.on_atomic: Callable[[str], None] | None = None
+        self.atomic_units: list[str] = []
+
+    def _atomic(self, name, fn):
+        with self._lock:
+            result = fn()
+        self.atomic_units.append(name)
+        hook = self.on_atomic
+        if hook is not None:
+            hook(name)
+        return result
 
     def ping(self):
+        # 健康探测不改状态，不计入原子单元。
         return True
 
     def set(self, key, value, ex=None, xx=False, nx=False):
+        return self._atomic("set", lambda: self._set(key, value, ex=ex, xx=xx, nx=nx))
+
+    def _set(self, key, value, ex=None, xx=False, nx=False):
         if xx and key not in self.store:
             return None
         if nx and key in self.store:
@@ -53,10 +93,16 @@ class FakeRedis:
         return True
 
     def get(self, key):
+        return self._atomic("get", lambda: self._get(key))
+
+    def _get(self, key):
         v = self.store.get(key)
         return v if isinstance(v, str) else None
 
     def delete(self, *keys):
+        return self._atomic("delete", lambda: self._delete(*keys))
+
+    def _delete(self, *keys):
         n = 0
         for k in keys:
             if k in self.store:
@@ -65,6 +111,9 @@ class FakeRedis:
         return n
 
     def rpush(self, key, *vals):
+        return self._atomic("rpush", lambda: self._rpush(key, *vals))
+
+    def _rpush(self, key, *vals):
         lst = self.store.get(key)
         if not isinstance(lst, list):
             lst = []
@@ -73,15 +122,24 @@ class FakeRedis:
         return len(lst)
 
     def lrange(self, key, start, end):
+        return self._atomic("lrange", lambda: self._lrange(key, start, end))
+
+    def _lrange(self, key, start, end):
         lst = self.store.get(key, [])
         if not isinstance(lst, list):
             return []
         return list(lst[start:]) if end == -1 else list(lst[start : end + 1])
 
     def expire(self, key, ttl):
+        return self._atomic("expire", lambda: self._expire(key, ttl))
+
+    def _expire(self, key, ttl):
         return key in self.store
 
     def sadd(self, key, *vals):
+        return self._atomic("sadd", lambda: self._sadd(key, *vals))
+
+    def _sadd(self, key, *vals):
         s = self.store.get(key)
         if not isinstance(s, set):
             s = set()
@@ -91,6 +149,9 @@ class FakeRedis:
         return len(s) - before
 
     def srem(self, key, *vals):
+        return self._atomic("srem", lambda: self._srem(key, *vals))
+
+    def _srem(self, key, *vals):
         s = self.store.get(key)
         if not isinstance(s, set):
             return 0
@@ -102,19 +163,25 @@ class FakeRedis:
         return removed
 
     def scard(self, key):
+        return self._atomic("scard", lambda: self._scard(key))
+
+    def _scard(self, key):
         s = self.store.get(key)
         return len(s) if isinstance(s, set) else 0
 
     def eval(self, script, numkeys, *keys_and_args):
+        return self._atomic("eval", lambda: self._eval(script, numkeys, *keys_and_args))
+
+    def _eval(self, script, numkeys, *keys_and_args):
         # 模拟 steering 的 run 释放脚本（SREM -> SCARD==0 -> DEL），与真实
         # Redis 一样在单次调用内原子完成。
         assert "SREM" in script and "SCARD" in script and "DEL" in script
         keys = keys_and_args[:numkeys]
         args = keys_and_args[numkeys:]
         runs_key = keys[0]
-        self.srem(runs_key, args[0])
-        if self.scard(runs_key) == 0:
-            self.delete(*keys)
+        self._srem(runs_key, args[0])
+        if self._scard(runs_key) == 0:
+            self._delete(*keys)
             return 1
         return 0
 
@@ -232,6 +299,154 @@ async def test_cleanup_without_run_id_still_removes_all_keys(redis_steering):
 
     await st.cleanup_steering_queue_async("sess-legacy")
     assert fake.store == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_run_is_atomic_against_concurrent_release(redis_steering):
+    """注册与释放并发：run-a 的释放脚本整段插到 run-b 注册中间时，也不能删掉
+    run-b 正在使用的 owner/msgs 键。
+
+    非原子注册（SET owner → SADD runs 两次 round-trip）下，释放脚本会在两者
+    之间看到空的 runs 集合并 DEL 掉三个键，结果 owner 缺失、runs={run-b}：
+    仍在流式生成的 run-b 剩余时间里所有 POST /agent/steer 都会 404，且已排队
+    的 steering 消息直接丢失。
+    """
+    st, fake = redis_steering
+    session_id = "sess-race"
+
+    # run-a 正在流式生成，并且已有一条尚未被消费的 steering 消息。
+    await st.create_steering_queue_async(session_id, "user-1", run_id="run-a")
+    queued = await st.get_steering_queue_for_user_async(session_id, "user-1")
+    await queued.add("保持第一人称")
+
+    release_may_start = threading.Event()
+    release_done = threading.Event()
+
+    def on_atomic(_unit: str) -> None:
+        # run-b 发出第一个原子单元之后，把 run-a 的整段释放插进来：注册若不是
+        # 原子的，插入点正好落在 SET owner 与 SADD runs 之间。
+        if threading.current_thread().name != "run-b" or release_may_start.is_set():
+            return
+        release_may_start.set()
+        assert release_done.wait(timeout=10), "run-a 的释放未完成"
+
+    fake.on_atomic = on_atomic
+
+    def register_run_b() -> None:
+        st._redis_create_sync(session_id, "user-1", "run-b")
+
+    def release_run_a() -> None:
+        assert release_may_start.wait(timeout=10), "run-b 未发出任何命令"
+        st._redis_cleanup_sync(session_id, "run-a")
+        release_done.set()
+
+    threads = [
+        threading.Thread(target=register_run_b, name="run-b"),
+        threading.Thread(target=release_run_a, name="run-a"),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+    fake.on_atomic = None
+    assert not any(t.is_alive() for t in threads), "注册/释放线程未退出（死锁）"
+
+    # run-b 仍在流式生成：owner 必须还在（否则 /steer 持续 404），
+    # runs 只剩 run-b，已排队的消息不能丢。
+    assert fake.store.get(st._owner_key(session_id)) == "user-1"
+    assert fake.store.get(st._runs_key(session_id)) == {"run-b"}
+    surviving = await st.get_steering_queue_for_user_async(session_id, "user-1")
+    assert [m.content for m in await surviving.peek()] == ["保持第一人称"]
+
+    # run-b 结束后才真正删除所有键。
+    await st.cleanup_steering_queue_async(session_id, run_id="run-b")
+    assert fake.store == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_registration_issues_single_atomic_unit(redis_steering):
+    """结构性保证：注册只发出一个原子单元（MULTI/EXEC），因此释放脚本不可能
+    观察到「owner 已写、runs 未写」的半注册状态。"""
+    st, fake = redis_steering
+
+    fake.atomic_units.clear()
+    await st.create_steering_queue_async("sess-atomic", "user-1", run_id="run-a")
+    assert fake.atomic_units == ["exec"]
+
+    # 不带 run_id 的注册同样只有一个原子单元。
+    fake.atomic_units.clear()
+    await st.create_steering_queue_async("sess-atomic-2", "user-1")
+    assert fake.atomic_units == ["exec"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_after_full_release_rebuilds_consistent_state(redis_steering):
+    """释放整段跑在注册之前时，注册要重建出一致状态（owner 与 runs 同时存在）。"""
+    st, fake = redis_steering
+    session_id = "sess-after-release"
+
+    await st.create_steering_queue_async(session_id, "user-1", run_id="run-a")
+    await st.cleanup_steering_queue_async(session_id, run_id="run-a")
+    assert fake.store == {}
+
+    await st.create_steering_queue_async(session_id, "user-1", run_id="run-b")
+    assert fake.store.get(st._owner_key(session_id)) == "user-1"
+    assert fake.store.get(st._runs_key(session_id)) == {"run-b"}
+    queue = await st.get_steering_queue_for_user_async(session_id, "user-1")
+    assert isinstance(queue, st.RedisSteeringQueue)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_steering_queue_async_does_not_downgrade_owner(redis_steering):
+    """不带 owner 的 get_steering_queue_async 只能在键缺失时占位，绝不能把
+    已绑定的真实 owner 覆盖成空串——否则 owner 校验会被整体绕过。"""
+    st, fake = redis_steering
+    session_id = "sess-owner-guard"
+
+    await st.create_steering_queue_async(session_id, "owner-user", run_id="run-a")
+    await st.get_steering_queue_async(session_id)
+
+    assert fake.store.get(st._owner_key(session_id)) == "owner-user"
+    with pytest.raises(PermissionError):
+        await st.get_steering_queue_for_user_async(session_id, "attacker-user")
+
+    # 键缺失时仍然占位创建（保持旧行为）。
+    await st.get_steering_queue_async("sess-fresh")
+    assert fake.store.get(st._owner_key("sess-fresh")) == ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_memory_path_concurrent_create_and_cleanup_keeps_queue(monkeypatch):
+    """内存回退路径：注册与释放共用同一把 asyncio.Lock，先结束的 run 不会
+    删掉另一个 run 仍在使用的队列。"""
+    import agent.core.steering as st
+
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    st._redis_health_checked_at = 0.0
+    st._redis_is_healthy = False
+
+    # 两种调度顺序都要成立：注册先拿到锁 / 释放先拿到锁。
+    for label, register_first in (("register-first", True), ("release-first", False)):
+        session_id = f"sess-mem-race-{label}"
+        await st.cleanup_steering_queue_async(session_id)
+        await st.create_steering_queue_async(session_id, "user-1", run_id="run-a")
+
+        register = st.create_steering_queue_async(session_id, "user-1", run_id="run-b")
+        release = st.cleanup_steering_queue_async(session_id, run_id="run-a")
+        await asyncio.gather(*((register, release) if register_first else (release, register)))
+
+        surviving = await st.get_steering_queue_for_user_async(session_id, "user-1")
+        await surviving.add("run-b 的引导消息")
+        assert [m.content for m in await surviving.peek()] == ["run-b 的引导消息"]
+
+        await st.cleanup_steering_queue_async(session_id, run_id="run-b")
+        with pytest.raises(KeyError):
+            await st.get_steering_queue_for_user_async(session_id, "user-1")
 
 
 @pytest.mark.unit

--- a/apps/server/tests/test_agent/test_steering_redis.py
+++ b/apps/server/tests/test_agent/test_steering_redis.py
@@ -81,6 +81,43 @@ class FakeRedis:
     def expire(self, key, ttl):
         return key in self.store
 
+    def sadd(self, key, *vals):
+        s = self.store.get(key)
+        if not isinstance(s, set):
+            s = set()
+            self.store[key] = s
+        before = len(s)
+        s.update(vals)
+        return len(s) - before
+
+    def srem(self, key, *vals):
+        s = self.store.get(key)
+        if not isinstance(s, set):
+            return 0
+        removed = 0
+        for v in vals:
+            if v in s:
+                s.remove(v)
+                removed += 1
+        return removed
+
+    def scard(self, key):
+        s = self.store.get(key)
+        return len(s) if isinstance(s, set) else 0
+
+    def eval(self, script, numkeys, *keys_and_args):
+        # 模拟 steering 的 run 释放脚本（SREM -> SCARD==0 -> DEL），与真实
+        # Redis 一样在单次调用内原子完成。
+        assert "SREM" in script and "SCARD" in script and "DEL" in script
+        keys = keys_and_args[:numkeys]
+        args = keys_and_args[numkeys:]
+        runs_key = keys[0]
+        self.srem(runs_key, args[0])
+        if self.scard(runs_key) == 0:
+            self.delete(*keys)
+            return 1
+        return 0
+
     def pipeline(self, transaction=True):
         return FakePipeline(self)
 
@@ -154,6 +191,47 @@ async def test_cleanup_removes_session(redis_steering):
     assert fake.store == {}
     with pytest.raises(KeyError):
         await st.get_steering_queue_for_user_async("sess-3", "user-1")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_runs_first_cleanup_keeps_other_runs_queue(redis_steering):
+    """同一 chat session 的并发 run 共享 steering 键：先结束的 run 不能删掉
+    另一个仍在流式生成的 run 正在使用的 owner 键与消息列表。"""
+    st, fake = redis_steering
+
+    await st.create_steering_queue_async("sess-shared", "user-1", run_id="run-a")
+    await st.create_steering_queue_async("sess-shared", "user-1", run_id="run-b")
+
+    queue = await st.get_steering_queue_for_user_async("sess-shared", "user-1")
+    await queue.add("run B 的引导消息")
+
+    # run A 先结束：owner/msgs 键必须保留，POST /steer 不能 404
+    await st.cleanup_steering_queue_async("sess-shared", run_id="run-a")
+
+    surviving = await st.get_steering_queue_for_user_async("sess-shared", "user-1")
+    pending = await surviving.peek()
+    assert [m.content for m in pending] == ["run B 的引导消息"]
+
+    # 最后一个持有者退出后所有键才删除
+    await st.cleanup_steering_queue_async("sess-shared", run_id="run-b")
+    assert fake.store == {}
+    with pytest.raises(KeyError):
+        await st.get_steering_queue_for_user_async("sess-shared", "user-1")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_without_run_id_still_removes_all_keys(redis_steering):
+    """不带 run_id 的 cleanup 保持旧语义：无条件删除全部键。"""
+    st, fake = redis_steering
+
+    await st.create_steering_queue_async("sess-legacy", "user-1", run_id="run-a")
+    q = await st.get_steering_queue_for_user_async("sess-legacy", "user-1")
+    await q.add("msg")
+
+    await st.cleanup_steering_queue_async("sess-legacy")
+    assert fake.store == {}
 
 
 @pytest.mark.unit

--- a/apps/server/tests/test_agent/test_stream_adapter.py
+++ b/apps/server/tests/test_agent/test_stream_adapter.py
@@ -1592,3 +1592,81 @@ async def test_truncated_prose_without_control_marker_is_still_saved():
     assert saved_args[0] == "file-2"
     assert "夜色沉沉" in saved_args[1]
     assert "[TASK_COMPLETE]" not in saved_args[1]
+
+
+@pytest.mark.unit
+async def test_fence_wrapped_file_block_is_saved_not_dumped_into_chat():
+    """模型把整块 <file>…</file> 包在 ``` 围栏里输出（提示词范例即这种写法）时，
+    正文必须落库；不能因为围栏保护把带原始标记的整章正文当成聊天消息、文件留空。"""
+    from agent.stream_adapter import create_stream_adapter
+    from agent.tools.mcp_tools import ToolContext
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+    ToolContext.set_pending_empty_file("file-3", "第53章")
+    adapter.set_pending_file_write("file-3", "draft", "第53章")
+
+    async def mock_events():
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "```markdown\n<file>"}
+        )
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "夜色沉沉，林川推开门。"}
+        )
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "</file>\n```"}
+        )
+        yield LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={})
+
+    events = [e async for e in adapter.process_workflow_events(mock_events())]
+
+    adapter._save_file_content.assert_awaited_once()
+    saved_args = adapter._save_file_content.await_args.args
+    assert saved_args[0] == "file-3"
+    assert saved_args[1] == "夜色沉沉，林川推开门。"
+
+    chat_text = "".join(
+        e.data.get("text", "") for e in events if e.type == EventType.CONTENT
+    )
+    assert "夜色沉沉" not in chat_text
+    assert "<file>" not in chat_text
+
+
+@pytest.mark.unit
+async def test_unclosed_fence_narration_then_file_block_is_saved():
+    """叙述里出现一个未闭合的 ``` 后再输出真实 <file> 正文：叙述进聊天、正文落库。
+
+    回归：开始标记因围栏可能在后续 chunk 闭合而全程判为歧义，若流结束时不复扫，
+    整章正文会连 <file>/</file> 原始标记一起被持久化成 assistant 消息。
+    """
+    from agent.stream_adapter import create_stream_adapter
+    from agent.tools.mcp_tools import ToolContext
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+    ToolContext.set_pending_empty_file("file-4", "第54章")
+    adapter.set_pending_file_write("file-4", "draft", "第54章")
+
+    async def mock_events():
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "好的，输出格式```\n"}
+        )
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "<file>雨停了，屋檐还在滴水。"}
+        )
+        yield LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "</file>已完成。"}
+        )
+        yield LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={})
+
+    events = [e async for e in adapter.process_workflow_events(mock_events())]
+
+    adapter._save_file_content.assert_awaited_once()
+    saved_args = adapter._save_file_content.await_args.args
+    assert saved_args[0] == "file-4"
+    assert saved_args[1] == "雨停了，屋檐还在滴水。"
+
+    chat_text = "".join(
+        e.data.get("text", "") for e in events if e.type == EventType.CONTENT
+    )
+    assert chat_text == "好的，输出格式```\n已完成。"

--- a/apps/server/tests/test_agent/test_stream_adapter.py
+++ b/apps/server/tests/test_agent/test_stream_adapter.py
@@ -1011,9 +1011,10 @@ class TestHandleCreateFileResult:
             "content": "Some content",
         }
 
-        await adapter._handle_create_file_result(result_data)
+        events = [e async for e in adapter._handle_create_file_result(result_data)]
 
         # Should NOT set pending file write because content exists
+        assert events == []
         assert adapter._pending_file_write is None
 
     @pytest.mark.asyncio
@@ -1026,11 +1027,28 @@ class TestHandleCreateFileResult:
             "content": "",
         }
 
-        await adapter._handle_create_file_result(result_data)
+        events = [e async for e in adapter._handle_create_file_result(result_data)]
 
         # Should set pending file write
+        assert events == []
         assert adapter._pending_file_write is not None
         assert adapter._pending_file_write.file_id == "file-1"
+
+    @pytest.mark.asyncio
+    async def test_create_file_empty_folder(self, adapter):
+        """folder 建档不得进入待写正文状态（它永远不会有 <file> 正文）。"""
+        result_data = {
+            "id": "folder-1",
+            "file_type": "folder",
+            "title": "第一卷",
+            "content": "",
+        }
+
+        events = [e async for e in adapter._handle_create_file_result(result_data)]
+
+        assert events == []
+        assert adapter._pending_file_write is None
+        assert adapter._stream_processor.state == StreamState.IDLE
 
 
 class TestHandleEditFileResult:
@@ -1670,3 +1688,271 @@ async def test_unclosed_fence_narration_then_file_block_is_saved():
         e.data.get("text", "") for e in events if e.type == EventType.CONTENT
     )
     assert chat_text == "好的，输出格式```\n已完成。"
+
+
+# ---------------------------------------------------------------------------
+# folder 是纯容器节点，永远不会收到 <file>…</file> 正文：
+# create_file(file_type="folder") 不得开启流式捕获（C2 回归）
+# ---------------------------------------------------------------------------
+
+
+def _create_file_result_event(
+    file_id: str,
+    file_type: str,
+    title: str,
+    content: str = "",
+) -> LangGraphStreamEvent:
+    """构造一个 create_file 的 TOOL_RESULT 事件（MCP 规范格式）。"""
+    payload = {
+        "status": "success",
+        "data": {
+            "id": file_id,
+            "title": title,
+            "file_type": file_type,
+            "content": content,
+        },
+    }
+    return LangGraphStreamEvent(
+        type=StreamEventType.TOOL_RESULT,
+        data={
+            "name": "create_file",
+            "tool_use_id": f"tu-{file_id}",
+            "result": {"content": [{"type": "text", "text": json.dumps(payload)}]},
+        },
+    )
+
+
+async def _drive_per_event(adapter, events) -> list[list]:
+    """逐个事件喂给 adapter，返回「每个输入事件当轮产出的 SSE 事件」列表。
+
+    必须按轮记录：folder 被当成待写正文文件时，叙述会被扣在 WAITING_START
+    缓冲里直到 MESSAGE_END 才一次性吐出（前端表现为长时间无输出），只看事件
+    总集合无法区分这种时序差异。
+    """
+    return [
+        [sse async for sse in adapter._process_workflow_event(event)]
+        for event in events
+    ]
+
+
+@pytest.mark.unit
+async def test_empty_folder_does_not_start_file_capture():
+    """创建空文件夹后，叙述必须在各自 TEXT 事件当轮就流出，处理器保持 IDLE。
+
+    回归：_handle_create_file_result 只看 content 为空就开启流式捕获，folder
+    同样命中，导致后续叙述全被缓冲到 MESSAGE_END 才吐出。
+    """
+    from agent.stream_adapter import create_stream_adapter
+    from agent.tools.mcp_tools import ToolContext
+
+    ToolContext.clear_pending_empty_file()
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+
+    rounds = await _drive_per_event(adapter, [
+        _create_file_result_event("folder-1", "folder", "第一卷"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "已为你建好「第一卷」文件夹，"}
+        ),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "接下来我会按大纲逐章写作。"}
+        ),
+        LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={"stop_reason": "end_turn"}),
+    ])
+
+    # folder 不是待写正文的目标：既不置 adapter 的 pending，也不让处理器进入捕获
+    assert adapter._pending_file_write is None
+    assert adapter._stream_processor.state == StreamState.IDLE
+
+    # file_created 事件仍要照常发出（前端据此刷新文件树）
+    assert [e.type for e in rounds[0]] == [EventType.TOOL_RESULT, EventType.FILE_CREATED]
+
+    # 叙述在当轮就流出，MESSAGE_END 不再补吐任何内容
+    assert [
+        e.data["text"] for e in rounds[1] if e.type == EventType.CONTENT
+    ] == ["已为你建好「第一卷」文件夹，"]
+    assert [
+        e.data["text"] for e in rounds[2] if e.type == EventType.CONTENT
+    ] == ["接下来我会按大纲逐章写作。"]
+    assert rounds[3] == []
+
+    adapter._save_file_content.assert_not_awaited()
+    assert ToolContext.has_pending_empty_file() is False
+
+
+@pytest.mark.unit
+async def test_empty_folder_file_type_variants_do_not_start_capture():
+    """folder 判定需归一化（大小写/空白），否则变体仍会开启流式捕获。"""
+    from agent.stream_adapter import create_stream_adapter
+
+    for raw_type in ("folder", "Folder", " FOLDER ", "folder\n"):
+        adapter = create_stream_adapter(
+            project_id="p", user_id="u", process_file_markers=True
+        )
+        await _drive_per_event(adapter, [
+            _create_file_result_event("folder-x", raw_type, "第一卷"),
+        ])
+        assert adapter._pending_file_write is None, raw_type
+        assert adapter._stream_processor.state == StreamState.IDLE, raw_type
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "file_type",
+    ["draft", "script", "outline", "character", "lore", "snippet", ""],
+)
+async def test_empty_content_bearing_file_still_starts_capture(file_type):
+    """承载正文的类型（含剧本分集复用返回的空 content）必须继续进入 WAITING_START。"""
+    from agent.stream_adapter import create_stream_adapter
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    await _drive_per_event(adapter, [
+        _create_file_result_event("file-1", file_type, "第一章"),
+    ])
+
+    assert adapter._pending_file_write is not None
+    assert adapter._pending_file_write.file_id == "file-1"
+    assert adapter._stream_processor.state == StreamState.WAITING_START
+
+
+@pytest.mark.unit
+async def test_folder_narration_with_fenced_file_example_is_not_written_to_folder():
+    """folder 后的叙述里出现 ``` 围栏包裹的成对 <file>…</file> 范例时，
+    范例必须原样进聊天，不得被流结束的 at_eof 兜底当成正文写进文件夹行。"""
+    from agent.stream_adapter import create_stream_adapter
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+
+    rounds = await _drive_per_event(adapter, [
+        _create_file_result_event("folder-2", "folder", "第一卷"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT,
+            data={
+                "text": "文件夹已创建。写作协议是这样的：\n\n"
+                        "```markdown\n<file>\n这里是正文示例，比如第一章的开头。\n</file>\n```\n\n"
+            },
+        ),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "明白了吗？我现在开始写第一章。"}
+        ),
+        LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={}),
+    ])
+    emitted = [e for round_events in rounds for e in round_events]
+
+    adapter._save_file_content.assert_not_awaited()
+    assert not [
+        e for e in emitted
+        if e.type in (EventType.FILE_CONTENT, EventType.FILE_CONTENT_END)
+    ]
+
+    chat_text = "".join(
+        e.data.get("text", "") for e in emitted if e.type == EventType.CONTENT
+    )
+    assert "这里是正文示例，比如第一章的开头。" in chat_text
+    assert "<file>" in chat_text
+    assert chat_text.endswith("明白了吗？我现在开始写第一章。")
+
+
+# ---------------------------------------------------------------------------
+# 新的空文件建档顶掉上一段流式捕获时，不得静默丢弃已缓冲的内容
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_new_pending_write_flushes_buffered_narration():
+    """WAITING_START 中缓冲的叙述必须在被下一次建档顶掉前吐出。
+
+    回归：set_pending_file_write -> start_file_write() 直接清空 temp_buffer，
+    夹在两次建档之间的叙述永久消失（0 个 content 事件）。
+    """
+    from agent.stream_adapter import create_stream_adapter
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+
+    rounds = await _drive_per_event(adapter, [
+        _create_file_result_event("draft-A", "draft", "第一章"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "先说明一下：这一章我会写得克制些。"}
+        ),
+        _create_file_result_event("draft-B", "draft", "第二章"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "<file>第二章正文。</file>"}
+        ),
+        LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={}),
+    ])
+
+    # 被顶掉的缓冲在「顶掉它的那一轮」就作为 content 吐出
+    assert [
+        e.data["text"] for e in rounds[2] if e.type == EventType.CONTENT
+    ] == ["先说明一下：这一章我会写得克制些。"]
+
+    # 新文件的正文正常落库，且不含那段叙述
+    adapter._save_file_content.assert_awaited_once()
+    saved_args = adapter._save_file_content.await_args.args
+    assert saved_args[0] == "draft-B"
+    assert saved_args[1] == "第二章正文。"
+
+
+@pytest.mark.unit
+async def test_new_pending_write_completes_displaced_unterminated_file():
+    """WRITING 中被顶掉时，上一份文件已缓冲的正文必须落库而不是被清空。"""
+    from agent.stream_adapter import create_stream_adapter
+
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+
+    await _drive_per_event(adapter, [
+        _create_file_result_event("draft-C", "draft", "第三章"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "<file>第三章开头，尚未闭合。"}
+        ),
+        _create_file_result_event("draft-D", "draft", "第四章"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "<file>第四章正文。</file>"}
+        ),
+        LangGraphStreamEvent(type=StreamEventType.MESSAGE_END, data={}),
+    ])
+
+    saved = [call.args for call in adapter._save_file_content.await_args_list]
+    assert saved == [
+        ("draft-C", "第三章开头，尚未闭合。"),
+        ("draft-D", "第四章正文。"),
+    ]
+
+
+@pytest.mark.unit
+async def test_displaced_completion_keeps_new_files_pending_empty_guard():
+    """收尾被顶掉的文件时，不能清掉已指向新文件的「空文件待补写」标记。
+
+    该标记是 writing_graph 判断「空文件必须被补写」的唯一信号，误清会让新建
+    的空文件永远无人补写。
+    """
+    from agent.stream_adapter import create_stream_adapter
+    from agent.tools.mcp_tools import ToolContext
+
+    ToolContext.clear_pending_empty_file()
+    adapter = create_stream_adapter(project_id="p", user_id="u", process_file_markers=True)
+    adapter._save_file_content = AsyncMock(return_value=True)
+
+    # draft-E 走的是「执行器复用/幂等路径返回 content=''」，入参带内容因此
+    # mcp_tools 没有为它置标记；随后新建的 draft-F 才是被标记的空文件。
+    await _drive_per_event(adapter, [
+        _create_file_result_event("draft-E", "draft", "第五章"),
+        LangGraphStreamEvent(
+            type=StreamEventType.TEXT, data={"text": "<file>第五章开头。"}
+        ),
+    ])
+    ToolContext.set_pending_empty_file("draft-F", "第六章")
+
+    await _drive_per_event(adapter, [
+        _create_file_result_event("draft-F", "draft", "第六章"),
+    ])
+
+    adapter._save_file_content.assert_awaited_once()
+    assert adapter._save_file_content.await_args.args == ("draft-E", "第五章开头。")
+    pending = ToolContext.get_pending_empty_file()
+    assert pending is not None and pending["file_id"] == "draft-F"
+
+    ToolContext.clear_pending_empty_file()

--- a/apps/server/tests/test_agent/test_stream_processor.py
+++ b/apps/server/tests/test_agent/test_stream_processor.py
@@ -80,3 +80,199 @@ def test_stream_end_while_draining_discards_tail():
     final = proc.finalize_on_stream_end()
     assert final.conversation_content == ""
     assert proc.state == StreamState.IDLE
+
+
+def test_inline_code_end_marker_in_body_is_content():
+    # 正文里用行内代码讨论 `</file>` 不能提前结束文件：
+    # 截断的文件 + 剩余正文/真实结束标记泄漏进对话流。
+    results, proc = _drive([
+        "<file>",
+        "正文第一段。用法示例：`</file>` 表示结束。",
+        "后半部分正文",
+        "</file>",
+    ])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == "正文第一段。用法示例：`</file>` 表示结束。后半部分正文"
+    assert _all_conversation(results) == ""
+
+
+def test_fenced_code_end_marker_in_body_is_content():
+    body = "第一段\n```\n</file>\n```\n第二段"
+    results, proc = _drive(["<file>" + body, "</file>"])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == body
+    assert _all_conversation(results) == ""
+
+
+def test_fenced_code_end_marker_survives_flush_boundary():
+    # 围栏开口先被 flush 出 temp_buffer，之后才出现 </file>：
+    # 围栏开合状态必须跨 flush 保留，否则围栏内的字面量被当成真实标记。
+    head = "A" * 100 + "\n```python\n"
+    body = head + "x" * 100 + "\n</file> 还在代码块里\n" + "```\n尾段"
+    results, proc = _drive([
+        "<file>" + head,
+        "x" * 100 + "\n</file> 还在代码块里\n",
+        "```\n尾段",
+        "</file>",
+    ])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == body
+    assert _all_conversation(results) == ""
+
+
+def test_inline_code_start_marker_in_narration_does_not_start_file():
+    # 叙述里行内代码 `<file>` 不是真实开始标记；真实标记随后到达时，
+    # 前面的叙述应作为对话输出，文件内容从真实标记之后开始。
+    results, proc = _drive([
+        "我会用 `<file>` 标记开始输出。",
+        "<file>正文",
+        "</file>",
+    ])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == "正文"
+    convo = _all_conversation(results)
+    assert "`<file>`" in convo
+    assert "正文" not in convo
+
+
+def test_backtick_and_end_marker_arriving_in_separate_chunks():
+    # 行内代码的反引号与 </file> 分属不同 chunk，重组后仍应识别为字面量
+    results, proc = _drive([
+        "<file>用法：`",
+        "</file>",
+        "` 表示结束。正文继续",
+        "</file>",
+    ])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == "用法：`</file>` 表示结束。正文继续"
+    assert _all_conversation(results) == ""
+
+
+def test_pending_inline_backtick_resolves_to_real_marker():
+    # 反引号后紧跟 </file>，但下一个字符不是反引号 -> 是真实结束标记
+    results, proc = _drive(["<file>末尾带`", "</file>", "后记"])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == "末尾带`"
+    assert _all_conversation(results) == "后记"
+
+
+def test_pending_inline_backtick_resolves_real_at_stream_end():
+    # 流结束时反引号不会再闭合，挂起的 </file> 应按真实结束标记处理
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    proc.process_content("<file>正文`")
+    proc.process_content("</file>")
+    final = proc.finalize_on_stream_end()
+    assert final.file_complete is True
+    assert final.final_content == "正文`"
+    assert proc.state == StreamState.IDLE
+
+
+def test_unclosed_fence_before_real_start_marker_resolves_at_stream_end():
+    # 叙述里出现一个未闭合的 ```：开始标记在流结束前始终无法判定（围栏可能
+    # 在后续 chunk 闭合）。流结束时围栏不会再闭合，必须按 at_eof 语义复扫，
+    # 正文写入文件，而不是把带 <file> 原始标记的整段正文倒进聊天。
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    results = [
+        proc.process_content("好的，输出格式```\n"),
+        proc.process_content("<file>这是正文第一段。"),
+        proc.process_content("</file>已完成。"),
+    ]
+    final = proc.finalize_on_stream_end()
+    assert final.file_complete is True
+    assert final.final_content == "这是正文第一段。"
+    convo = _all_conversation([*results, final])
+    assert convo == "好的，输出格式```\n已完成。"
+    assert "<file>" not in convo
+    assert proc.state == StreamState.IDLE
+
+
+def test_fence_wrapped_file_block_is_written_at_stream_end():
+    # 模型把整块 <file>…</file> 包在 ``` 围栏里输出（提示词范例本身就是这种
+    # 写法）：围栏保护让开始标记全程被判为字面量。流结束时应放宽围栏保护把
+    # 正文写入文件，而不是让整章正文连标记一起变成聊天消息、文件留空。
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    results = [
+        proc.process_content("```markdown\n<file>"),
+        proc.process_content("第一段正文。"),
+        proc.process_content("</file>\n```"),
+    ]
+    final = proc.finalize_on_stream_end()
+    assert final.file_complete is True
+    assert final.final_content == "第一段正文。"
+    convo = _all_conversation([*results, final])
+    assert "第一段正文。" not in convo
+    assert "<file>" not in convo
+    assert proc.state == StreamState.IDLE
+
+
+def test_fenced_format_explanation_without_end_marker_stays_conversation():
+    # 只在围栏里解释格式、没有配对的 </file>：不是文件正文，流结束时仍按叙述
+    # flush 进对话，文件保持未写入（交由工作流的空文件纠正循环重跑 writer）。
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    narration = "格式示例：\n```\n<file>\n```\n请确认后我再写。"
+    proc.process_content(narration)
+    final = proc.finalize_on_stream_end()
+    assert final.file_complete is False
+    assert final.conversation_content == narration
+    assert proc.state == StreamState.IDLE
+
+
+def test_at_eof_rescan_still_honours_control_marker_guard():
+    # at_eof 复扫命中开始标记后走的是 WRITING finalize 路径，因此仍受 control
+    # marker 污染守卫约束：交接叙述不得被当成正文落库。
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    proc.process_content("输出格式```\n")
+    proc.process_content("<file>正文文件已创建。\n\n")
+    proc.process_content("### 已交接给 writer。[TASK_COMPLETE]")
+    final = proc.finalize_on_stream_end()
+    assert final.file_complete is False
+    assert final.conversation_content == (
+        "输出格式```\n正文文件已创建。\n\n### 已交接给 writer。[TASK_COMPLETE]"
+    )
+    assert proc.state == StreamState.IDLE
+
+
+def test_inline_code_narration_stays_conversation_at_stream_end():
+    # 行内代码里的 `<file>` 到流结束仍是字面量，不能被 at_eof 复扫误判成
+    # 真实开始标记而把叙述写进文件。
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    narration = "我会用 `<file>` 标记开始输出，请稍等。"
+    proc.process_content(narration)
+    final = proc.finalize_on_stream_end()
+    assert final.file_complete is False
+    assert final.conversation_content == narration
+    assert proc.state == StreamState.IDLE
+
+
+def test_end_marker_split_across_chunks_still_completes():
+    results, proc = _drive(["<file>你好", "</fi", "le>尾巴"])
+    assert proc.state == StreamState.IDLE
+    completed = next(r for r in results if r.file_complete)
+    assert completed.final_content == "你好"
+    assert _all_conversation(results) == "尾巴"
+
+
+def test_drain_ignores_inline_code_end_marker():
+    proc = StreamProcessor()
+    proc.start_file_write("file-1")
+    proc.process_content("<file>")
+    proc.process_content("x" * (BUFFER_MAX_SIZE + 100))
+    assert proc.state == StreamState.DRAINING
+    leaked = proc.process_content("尾部提到 `</file>` 仍是溢出内容")
+    assert leaked.conversation_content == ""
+    assert proc.state == StreamState.DRAINING
+    closing = proc.process_content("</file>之后的对话")
+    assert closing.conversation_content == "之后的对话"
+    assert proc.state == StreamState.IDLE

--- a/apps/server/tests/test_agent/test_text_matching_boundary.py
+++ b/apps/server/tests/test_agent/test_text_matching_boundary.py
@@ -1,0 +1,59 @@
+"""Regression tests for NFKC-expansion boundary handling in fuzzy matching.
+
+NFKC normalization can expand one original character into several normalized
+characters (Ⅻ→xii, ﬁ→fi, ㎞→km); index_map maps all of them back to the same
+original index. A fuzzy span that starts or ends in the middle of such an
+expansion must be rejected (or shrunk, for approximate matching) instead of
+swallowing the whole original character including its unmatched remainder.
+"""
+
+from agent.tools.file_ops.text_matching import (
+    find_approximate_match,
+    find_fuzzy_spans,
+)
+
+CONTENT = "他们说序章完毕。第Ⅻ章开始了……"
+
+
+def test_pattern_ending_mid_expansion_is_rejected():
+    """LLM 把 Ⅻ 误写成 x：span 终点落在展开字符中间，必须拒绝而非吞掉整个 Ⅻ。"""
+    stats: dict[str, int] = {}
+    spans = find_fuzzy_spans(CONTENT, "序章完毕第x", stats=stats)
+    assert spans == []
+    assert stats["boundary_rejected"] == 1
+
+
+def test_pattern_starting_mid_expansion_is_rejected():
+    """span 起点落在展开字符中间同样必须拒绝。"""
+    stats: dict[str, int] = {}
+    spans = find_fuzzy_spans(CONTENT, "ii章开始了", stats=stats)
+    assert spans == []
+    assert stats["boundary_rejected"] == 1
+
+
+def test_pattern_covering_full_expansion_still_matches():
+    """覆盖完整展开序列（xii）的 pattern 仍应正常匹配到整个 Ⅻ。"""
+    spans = find_fuzzy_spans(CONTENT, "序章完毕第xii")
+    assert len(spans) == 1
+    start, end = spans[0]
+    assert CONTENT[start:end] == "序章完毕。第Ⅻ"
+
+
+def test_stats_report_zero_when_no_boundary_issue():
+    stats: dict[str, int] = {}
+    spans = find_fuzzy_spans(CONTENT, "章开始了", stats=stats)
+    # 归一化后不足 min_normalized_len 也不应误报 boundary_rejected
+    assert stats["boundary_rejected"] == 0
+    assert spans == []
+
+
+def test_approximate_match_shrinks_partial_expansion():
+    """近似匹配窗口终点落在展开字符中间时，应收缩到对齐边界而非吞掉 Ⅻ。"""
+    content = "他们说的序章今天完毕。第Ⅻ章开始了。"
+    pattern = "他们说的序章今天完毕第x"
+    match = find_approximate_match(content, pattern, max_error_rate=0.2, min_pattern_len=10)
+    assert match is not None
+    start, end, _score, matched_text = match
+    assert "Ⅻ" not in matched_text
+    assert end <= content.index("Ⅻ")
+    assert 0 <= start < end

--- a/apps/server/tests/test_agent/test_token_utils.py
+++ b/apps/server/tests/test_agent/test_token_utils.py
@@ -1,7 +1,12 @@
 """Tests for token estimation utilities."""
 
 
-from agent.utils.token_utils import estimate_message_tokens, estimate_text_tokens
+from agent.utils.token_utils import (
+    _chars_per_token_for,
+    _cjk_fraction,
+    estimate_message_tokens,
+    estimate_text_tokens,
+)
 
 # ---------------------------------------------------------------------------
 # estimate_text_tokens
@@ -112,3 +117,41 @@ def test_empty_content_returns_zero_or_one():
     msg = {"role": "user", "content": ""}
     # Empty content — result is 0 or 1 (max(1, ...) guard might not fire for empty)
     assert estimate_message_tokens(msg) >= 0
+
+
+def test_assistant_thinking_blocks_do_not_consume_history_budget():
+    """Thinking blocks are dropped before replay, so they must not be billed."""
+    text_block = {"type": "text", "text": "Final answer for the user."}
+    with_thinking = {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "reasoning " * 500},
+            text_block,
+        ],
+    }
+    text_only = {"role": "assistant", "content": [text_block]}
+
+    assert estimate_message_tokens(with_thinking) == estimate_message_tokens(text_only)
+
+
+# ---------------------------------------------------------------------------
+# _cjk_fraction / _chars_per_token_for
+# ---------------------------------------------------------------------------
+
+
+def test_cjk_extension_b_counts_as_cjk():
+    assert _cjk_fraction(chr(0x20000) * 10) == 1.0
+    assert _cjk_fraction(chr(0x2A6DF) * 10) == 1.0
+
+
+def test_general_punctuation_and_symbols_are_not_cjk():
+    # Curly quotes, em dash, ellipsis, arrow, for-all — all inside U+2001..U+2A6D
+    assert _cjk_fraction("‘’“”—…→∀") == 0.0
+
+
+def test_chars_per_token_uses_cjk_ratio_for_extension_b_text():
+    assert _chars_per_token_for(chr(0x20000) * 20) == 2.0
+
+
+def test_chars_per_token_keeps_latin_ratio_for_symbol_heavy_text():
+    assert _chars_per_token_for("‘’“”—…→∀") == 4.0

--- a/apps/server/tests/test_agent/test_writing_graph.py
+++ b/apps/server/tests/test_agent/test_writing_graph.py
@@ -2,6 +2,7 @@
 Tests for agent/graph/writing_graph.py
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -814,6 +815,58 @@ class TestWritingGraphFileCorrection:
         assert any(event.type == StreamEventType.WORKFLOW_COMPLETE for event in events)
 
     @pytest.mark.asyncio
+    async def test_empty_file_flag_set_in_tool_subtask_still_triggers_correction(self):
+        """标记在 SDK 包的工具子任务里设置时，图循环（父上下文）仍必须触发纠偏重跑。
+
+        openai-agents SDK 为每次 function tool 调用包一层 asyncio.create_task，
+        create_file 的 pending 标记就是在那个子任务里设置的。
+        """
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+
+        calls: list[str] = []
+
+        async def fake_run_streaming_agent(state, agent_type, *_args, **_kwargs):
+            calls.append(agent_type)
+            if len(calls) == 1:
+                # 模拟 SDK 在独立子任务里执行 create_file 工具并设置标记
+                async def tool_task():
+                    ToolContext.set_pending_empty_file("file-X", "第51章")
+
+                await asyncio.create_task(tool_task())
+                yield StreamEvent(
+                    type=StreamEventType.TEXT,
+                    data={"text": "正文文件已创建，需直接写入内容。[TASK_COMPLETE]"},
+                )
+            else:
+                ToolContext.clear_pending_empty_file()
+                yield StreamEvent(
+                    type=StreamEventType.TEXT,
+                    data={"text": "已用 edit_file 补全正文。[TASK_COMPLETE]"},
+                )
+
+        state = {"user_message": "写第51章", "messages": [], "system_prompt": ""}
+
+        ToolContext.set_context(
+            session=None, user_id="u", project_id="p", session_id="s",
+        )
+        try:
+            with (
+                patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+                patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+                patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+            ):
+                _ = [
+                    event async for event in run_writing_workflow_streaming(
+                        state=state, thread_id="t",
+                    )
+                ]
+        finally:
+            ToolContext.clear_context()
+
+        # 原始一轮 + 一次纠偏重跑
+        assert calls == ["writer", "writer"]
+
+    @pytest.mark.asyncio
     async def test_correction_is_bounded_and_does_not_loop_forever(self):
         from agent.graph.writing_graph import MAX_FILE_CORRECTION_ATTEMPTS, run_writing_workflow_streaming
 
@@ -849,3 +902,307 @@ class TestWritingGraphFileCorrection:
 
         # Initial turn + at most MAX_FILE_CORRECTION_ATTEMPTS corrective re-runs.
         assert len(calls) <= 1 + MAX_FILE_CORRECTION_ATTEMPTS
+
+
+@pytest.mark.unit
+class TestWritingGraphFileCorrectionDbVerification:
+    """纠偏必须先落库核验正文，避免 edit_file 已写完正文时被误判为空文件。
+
+    pending-empty-file 标记只表示"没走 <file>…</file> 流式写入"，edit_file
+    写正文不会清除它，所以标记仍在不等于正文为空。
+    """
+
+    @staticmethod
+    def _make_file(db_session, *, content: str, is_deleted: bool = False):
+        from models import File
+
+        file = File(
+            project_id="project-empty-guard",
+            title="第一章",
+            content=content,
+            file_type="draft",
+            is_deleted=is_deleted,
+        )
+        db_session.add(file)
+        db_session.commit()
+        db_session.refresh(file)
+        return file
+
+    @staticmethod
+    async def _run(db_session, file_id: str, title: str) -> list[dict]:
+        """跑一轮 writer：工具阶段置上 pending 标记，正文由 edit_file 侧写库。"""
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+
+        calls: list[dict] = []
+
+        async def fake_run_streaming_agent(state, agent_type, *_args, **_kwargs):
+            calls.append({"agent": agent_type, "user_message": state.get("user_message", "")})
+            if len(calls) == 1:
+                # 只有第一轮调用了 create_file(空)，标记因此只置一次
+                ToolContext.set_pending_empty_file(file_id, title)
+            yield StreamEvent(
+                type=StreamEventType.TEXT,
+                data={"text": "已写入正文。[TASK_COMPLETE]"},
+            )
+
+        state = {"user_message": "写第一章", "messages": [], "system_prompt": ""}
+
+        ToolContext.set_context(
+            session=db_session, user_id="u", project_id="project-empty-guard", session_id="s",
+        )
+        try:
+            with (
+                patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+                patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+                patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+            ):
+                _ = [
+                    event async for event in run_writing_workflow_streaming(
+                        state=state, thread_id="t",
+                    )
+                ]
+        finally:
+            ToolContext.clear_context()
+
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_body_written_by_edit_file_does_not_trigger_rerun(self, db_session):
+        """create_file(空) + edit_file(op=append) 写完正文后，绝不能再跑一轮纠偏。
+
+        否则纠偏轮会按"正文仍为空"的指令再 append 一遍完整正文，文件里出现两份正文。
+        """
+        file = self._make_file(db_session, content="第一章正文" * 50)
+
+        calls = await self._run(db_session, file.id, file.title)
+
+        assert len(calls) == 1, "正文已落库时不得触发纠偏重跑"
+
+    @pytest.mark.asyncio
+    async def test_still_empty_body_triggers_rerun(self, db_session):
+        """正文确实为空时，纠偏兜底必须保留。"""
+        file = self._make_file(db_session, content="   \n  ")
+
+        calls = await self._run(db_session, file.id, file.title)
+
+        assert len(calls) == 2
+        assert "正文仍为空" in calls[1]["user_message"]
+        assert file.id in calls[1]["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_deleted_file_does_not_trigger_rerun(self, db_session):
+        """文件已被删除时无正文可补，不应白烧一轮 writer。"""
+        file = self._make_file(db_session, content="", is_deleted=True)
+
+        calls = await self._run(db_session, file.id, file.title)
+
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_file_does_not_trigger_rerun(self, db_session):
+        calls = await self._run(db_session, "file-not-in-db", "第一章")
+
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_body_written_in_other_session_is_seen(self, db_session):
+        """正文由工具自己的 session 写入时，核验必须读数据库最新值。
+
+        offload 路径下 edit_file 用独立 session 提交，图上下文的 session 里可能
+        还缓存着 content="" 的旧实例；按缓存判断会把已写完的文件误判为空文件。
+        """
+        from sqlmodel import Session
+
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+        from models import File
+
+        file = self._make_file(db_session, content="")
+        # 让图上下文的 session 先缓存一份 content="" 的实例
+        assert db_session.get(File, file.id).content == ""
+
+        engine = db_session.get_bind()
+        calls: list[str] = []
+
+        async def fake_run_streaming_agent(state, agent_type, *_args, **_kwargs):
+            calls.append(agent_type)
+            if len(calls) == 1:
+                ToolContext.set_pending_empty_file(file.id, file.title)
+                with Session(engine) as tool_session:
+                    target = tool_session.get(File, file.id)
+                    target.content = "第一章正文" * 50
+                    tool_session.add(target)
+                    tool_session.commit()
+            yield StreamEvent(
+                type=StreamEventType.TEXT,
+                data={"text": "已写入正文。[TASK_COMPLETE]"},
+            )
+
+        state = {"user_message": "写第一章", "messages": [], "system_prompt": ""}
+
+        ToolContext.set_context(
+            session=db_session, user_id="u", project_id="project-empty-guard", session_id="s",
+        )
+        try:
+            with (
+                patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+                patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+                patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+            ):
+                _ = [
+                    event async for event in run_writing_workflow_streaming(
+                        state=state, thread_id="t",
+                    )
+                ]
+        finally:
+            ToolContext.clear_context()
+
+        assert calls == ["writer"]
+
+
+@pytest.mark.unit
+class TestWritingGraphSteeringFollowup:
+    """运行期间到达的 steering 必须在本次请求内触发追加轮，而不是被丢弃。"""
+
+    @pytest.mark.asyncio
+    async def test_mid_run_steering_triggers_writer_followup(self):
+        """runner 在工具边界消费到的 steering（steering_received 事件）应让
+        graph 在工作流收尾前追加一轮 writer。"""
+        from agent.core.events import steering_received_event
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+
+        calls: list[dict] = []
+
+        async def fake_run_streaming_agent(state, agent_type, get_steering_messages=None):
+            calls.append({"agent_type": agent_type, "state": dict(state)})
+            if len(calls) == 1:
+                yield StreamEvent(type=StreamEventType.MESSAGE_START, data={})
+                yield StreamEvent(type=StreamEventType.TEXT, data={"text": "第一章内容"})
+                # 模拟 runner 在工具输出边界消费到 steering：发确认事件并把
+                # 内容作为用户消息写回 state（与真实 runner 行为一致）。
+                yield steering_received_event(message_id="steer-1", preview="改成第一人称")
+                state["messages"] = list(state.get("messages") or []) + [
+                    {"role": "user", "content": "改成第一人称"}
+                ]
+            else:
+                yield StreamEvent(type=StreamEventType.MESSAGE_START, data={})
+                yield StreamEvent(type=StreamEventType.TEXT, data={"text": "已按引导调整"})
+
+        async def get_steering_messages():
+            # 队列已被 runner 在边界消费，graph 边界轮询拿不到新消息
+            return []
+
+        state = {"user_message": "写第一章", "messages": [], "system_prompt": ""}
+
+        with (
+            patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+            patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+            patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+        ):
+            events = [
+                event async for event in run_writing_workflow_streaming(
+                    state=state,
+                    thread_id="t",
+                    get_steering_messages=get_steering_messages,
+                )
+            ]
+
+        assert len(calls) == 2, "运行中消费到 steering 后必须追加一轮 writer"
+        assert calls[1]["agent_type"] == "writer"
+        followup_message = calls[1]["state"]["user_message"]
+        assert "引导" in followup_message
+        # 引导内容已在会话历史中，追加轮能看到
+        assert {"role": "user", "content": "改成第一人称"} in calls[1]["state"]["messages"]
+        assert not any(
+            event.type == StreamEventType.ITERATION_EXHAUSTED for event in events
+        )
+
+    @pytest.mark.asyncio
+    async def test_boundary_steering_consumed_before_workflow_stops(self):
+        """纯文本生成期间到达、run 内没有工具边界可消费的 steering，必须在
+        工作流收尾前由 graph 消费并触发追加轮（而不是留给 cleanup 删除）。"""
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+
+        calls: list[dict] = []
+
+        async def fake_run_streaming_agent(state, agent_type, get_steering_messages=None):
+            calls.append({"agent_type": agent_type, "state": dict(state)})
+            yield StreamEvent(type=StreamEventType.MESSAGE_START, data={})
+            yield StreamEvent(type=StreamEventType.TEXT, data={"text": "一段生成内容"})
+
+        steering_polls = {"n": 0}
+
+        async def get_steering_messages():
+            steering_polls["n"] += 1
+            if steering_polls["n"] == 1:
+                return [{"id": "steer-2", "content": "结尾加一个反转"}]
+            return []
+
+        state = {"user_message": "写一段", "messages": [], "system_prompt": ""}
+
+        with (
+            patch("agent.graph.writing_graph.router_node", AsyncMock(return_value={})),
+            patch("agent.graph.writing_graph.get_next_node", return_value="writer"),
+            patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+        ):
+            events = [
+                event async for event in run_writing_workflow_streaming(
+                    state=state,
+                    thread_id="t",
+                    get_steering_messages=get_steering_messages,
+                )
+            ]
+
+        assert steering_polls["n"] >= 1, "graph 必须在 agent 边界轮询 steering 队列"
+        assert len(calls) == 2, "边界消费到 steering 后必须追加一轮 writer"
+        # 消费到的消息要向前端确认，并作为用户消息进入追加轮的会话历史
+        assert any(
+            getattr(event.type, "value", "") == "steering_received" for event in events
+        )
+        assert {"role": "user", "content": "结尾加一个反转"} in calls[1]["state"]["messages"]
+
+    @pytest.mark.asyncio
+    async def test_steering_followup_skipped_when_planned_agent_remains(self):
+        """已有计划中的下一个 agent 时不追加 writer 轮：steering 会经由下一个
+        agent 的起始注入/会话历史生效，避免打乱计划工作流。"""
+        from agent.core.events import steering_received_event
+        from agent.graph.writing_graph import run_writing_workflow_streaming
+
+        calls: list[str] = []
+
+        async def fake_run_streaming_agent(state, agent_type, get_steering_messages=None):
+            calls.append(agent_type)
+            yield StreamEvent(type=StreamEventType.MESSAGE_START, data={})
+            if agent_type == "planner":
+                yield steering_received_event(message_id="steer-3", preview="主角改名林川")
+                state["messages"] = list(state.get("messages") or []) + [
+                    {"role": "user", "content": "主角改名林川"}
+                ]
+            yield StreamEvent(type=StreamEventType.TEXT, data={"text": f"{agent_type} 输出"})
+
+        async def get_steering_messages():
+            return []
+
+        router_result = {
+            "current_agent": "planner",
+            "workflow_plan": "standard",
+            "workflow_agents": ["writer"],
+            "routing_metadata": {},
+        }
+
+        state = {"user_message": "规划并写作", "messages": [], "system_prompt": ""}
+
+        with (
+            patch("agent.graph.writing_graph.router_node", AsyncMock(return_value=router_result)),
+            patch("agent.graph.writing_graph.get_next_node", return_value="planner"),
+            patch("agent.graph.writing_graph.run_streaming_agent", new=fake_run_streaming_agent),
+        ):
+            _ = [
+                event async for event in run_writing_workflow_streaming(
+                    state=state,
+                    thread_id="t",
+                    get_steering_messages=get_steering_messages,
+                )
+            ]
+
+        # planner -> writer（计划交接），writer 收尾后无新 steering，不再追加
+        assert calls == ["planner", "writer"]

--- a/apps/server/tests/test_api/test_agent.py
+++ b/apps/server/tests/test_api/test_agent.py
@@ -930,3 +930,114 @@ async def test_agent_steer_rejects_empty_message(client: AsyncClient, db_session
         assert response.status_code == 400
     finally:
         await cleanup_steering_queue_async(session_id)
+
+
+@pytest.mark.integration
+async def test_agent_stream_releases_request_transaction_before_streaming(
+    client: AsyncClient,
+    db_session: Session,
+):
+    """The request-scoped session must not hold an open transaction during SSE."""
+    user = User(
+        username="agent_user_txn",
+        email="agent_user_txn@example.com",
+        hashed_password=hash_password("password123"),
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    login_response = await client.post(
+        "/api/auth/login",
+        data={"username": "agent_user_txn", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+    token = login_response.json()["access_token"]
+
+    project = Project(name="Agent Txn Project", owner_id=user.id)
+    db_session.add(project)
+    db_session.commit()
+
+    in_transaction_at_stream_start: list[bool] = []
+
+    class MockAgentService:
+        async def process_stream(self, **kwargs):
+            in_transaction_at_stream_start.append(kwargs["session"].in_transaction())
+            yield "event: done\ndata: {}\n\n"
+
+    def _fresh_session():
+        return Session(db_session.get_bind())
+
+    # 清空 identity map，强制鉴权/权限校验真正发 SELECT 并 autobegin 事务
+    # （否则测试内 add+commit 过的 User/Project 会命中缓存，压根开不了事务）。
+    db_session.expunge_all()
+
+    # 模拟 Postgres 路径：配额读写走独立 session，请求级 session 只承担
+    # 鉴权/权限校验的 SELECT（正是会挂住 idle in transaction 的场景）。
+    with (
+        patch("api.agent.get_agent_service", return_value=MockAgentService()),
+        patch("api.agent._should_offload_session_work", return_value=True),
+        patch("api.agent.create_session", side_effect=_fresh_session),
+    ):
+        response = await client.post(
+            "/api/v1/agent/stream",
+            json={
+                "project_id": str(project.id),
+                "message": "Hello",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert in_transaction_at_stream_start == [False]
+
+
+@pytest.mark.integration
+async def test_agent_stream_auth_failure_paths_unchanged_after_txn_release(
+    client: AsyncClient,
+    db_session: Session,
+):
+    """Releasing the request transaction must not alter auth/permission failures."""
+    owner = User(
+        username="agent_user_txn_owner",
+        email="agent_user_txn_owner@example.com",
+        hashed_password=hash_password("password123"),
+        email_verified=True,
+        is_active=True,
+    )
+    intruder = User(
+        username="agent_user_txn_intruder",
+        email="agent_user_txn_intruder@example.com",
+        hashed_password=hash_password("password123"),
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add_all([owner, intruder])
+    db_session.commit()
+
+    project = Project(name="Agent Txn Foreign Project", owner_id=owner.id)
+    db_session.add(project)
+    db_session.commit()
+
+    login_response = await client.post(
+        "/api/auth/login",
+        data={"username": "agent_user_txn_intruder", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+    intruder_token = login_response.json()["access_token"]
+
+    # Unauthenticated request
+    response = await client.post(
+        "/api/v1/agent/stream",
+        json={"project_id": str(project.id), "message": "Hello"},
+    )
+    assert response.status_code == 401
+
+    # Authenticated but not the project owner
+    response = await client.post(
+        "/api/v1/agent/stream",
+        json={"project_id": str(project.id), "message": "Hello"},
+        headers={"Authorization": f"Bearer {intruder_token}"},
+    )
+    assert response.status_code == 403

--- a/apps/server/tests/test_api/test_chat.py
+++ b/apps/server/tests/test_api/test_chat.py
@@ -249,6 +249,73 @@ class TestChatAPI:
         assert data[1]["role"] == "assistant"
         assert data[1]["content"] == "I'm doing well, thank you!"
 
+    async def test_get_session_messages_returns_latest_when_over_limit(
+        self, client: AsyncClient, db_session: Session
+    ):
+        """当消息数超过 limit 时应返回最近的 limit 条（升序输出），而非最旧的一页。"""
+        from datetime import timedelta
+
+        from config.datetime_utils import utcnow
+
+        user = User(
+            username="testuser4b",
+            email="testuser4b@example.com",
+            hashed_password=hash_password("password123"),
+            name="Test User 4b",
+            email_verified=True,
+            is_active=True,
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        project = Project(
+            id="proj-test-4b",
+            owner_id=user.id,
+            name="Test Project",
+            description="Test Description",
+        )
+        db_session.add(project)
+        db_session.commit()
+
+        session = ChatSession(
+            user_id=user.id,
+            project_id=project.id,
+            title="Test Session",
+            is_active=True,
+            message_count=5,
+        )
+        db_session.add(session)
+        db_session.commit()
+
+        base = utcnow()
+        for i in range(5):
+            db_session.add(
+                ChatMessage(
+                    session_id=session.id,
+                    role="user" if i % 2 == 0 else "assistant",
+                    content=f"message-{i}",
+                    created_at=base + timedelta(seconds=i),
+                )
+            )
+        db_session.commit()
+
+        response = await client.post(
+            "/api/auth/login",
+            data={"username": "testuser4b", "password": "password123"},
+        )
+        assert response.status_code == 200
+        token = response.json()["access_token"]
+
+        response = await client.get(
+            f"/api/v1/chat/session/{project.id}/messages",
+            params={"limit": 2},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [msg["content"] for msg in data] == ["message-3", "message-4"]
+
     async def test_clear_session_success(
         self, client: AsyncClient, db_session: Session
     ):

--- a/apps/server/tests/test_services/test_file_version_service.py
+++ b/apps/server/tests/test_services/test_file_version_service.py
@@ -9,6 +9,8 @@ Unit tests for the file version management service, covering:
 - Edge cases and error handling
 """
 
+import random
+
 import pytest
 from sqlmodel import Session
 
@@ -589,6 +591,148 @@ class TestFileVersionServiceRollback:
                 file_id=test_file_with_project.id,
                 version_number=999,
                 user_id="test-user",
+            )
+
+
+@pytest.mark.unit
+class TestFileVersionServiceDiffReplay:
+    """Tests for diff replay when content lines look like diff headers.
+
+    Deleted lines starting with "--" (e.g. Markdown "---" separators) and
+    added lines starting with "++" produce diff lines that share a prefix
+    with unified diff file headers, and must not be skipped during replay.
+    """
+
+    def _roundtrip(self, db_session, service, file, contents):
+        """Create a version per content, then reconstruct each and compare."""
+        versions = [
+            service.create_version(
+                session=db_session,
+                file_id=file.id,
+                new_content=content,
+            )
+            for content in contents
+        ]
+        for version, expected in zip(versions, contents, strict=True):
+            actual = service.get_content_at_version(
+                session=db_session,
+                file_id=file.id,
+                version_number=version.version_number,
+            )
+            assert actual == expected, (
+                f"Version {version.version_number} replayed incorrectly:\n"
+                f"expected: {expected!r}\nactual: {actual!r}"
+            )
+        return versions
+
+    def test_delete_markdown_separator_line(self, db_session: Session, file_version_service, test_file_with_project):
+        """Deleting a '---' separator line must survive delta replay."""
+        versions = self._roundtrip(
+            db_session,
+            file_version_service,
+            test_file_with_project,
+            [
+                "章节开头\n---\n结尾\n",
+                "章节开头\n***\n结尾\n",
+            ],
+        )
+        assert versions[1].is_base_version is False
+
+    def test_add_line_starting_with_plus_plus(self, db_session: Session, file_version_service, test_file_with_project):
+        """Adding a line starting with '++' must survive delta replay."""
+        versions = self._roundtrip(
+            db_session,
+            file_version_service,
+            test_file_with_project,
+            [
+                "第一行\n第二行\n",
+                "第一行\n++重点标记\n第二行\n",
+            ],
+        )
+        assert versions[1].is_base_version is False
+
+    def test_remove_frontmatter_block(self, db_session: Session, file_version_service, test_file_with_project):
+        """Removing a YAML frontmatter block deletes '---' delimiter lines."""
+        versions = self._roundtrip(
+            db_session,
+            file_version_service,
+            test_file_with_project,
+            [
+                "---\ntitle: 第一章\ntags: 修仙\n---\n\n正文开始\n",
+                "正文开始\n",
+                "---\ntitle: 第一章（修订）\n---\n\n正文开始\n",
+            ],
+        )
+        assert versions[1].is_base_version is False
+        assert versions[2].is_base_version is False
+
+    def test_rollback_restores_content_with_separator(self, db_session: Session, file_version_service, test_file_with_project):
+        """Rollback across a '---' deletion must restore exact content."""
+        v1_content = "章节开头\n---\n结尾\n"
+        file_version_service.create_version(
+            session=db_session,
+            file_id=test_file_with_project.id,
+            new_content=v1_content,
+        )
+        v2 = file_version_service.create_version(
+            session=db_session,
+            file_id=test_file_with_project.id,
+            new_content="章节开头\n***\n结尾\n",
+        )
+        assert v2.is_base_version is False
+
+        file, _ = file_version_service.rollback_to_version(
+            session=db_session,
+            file_id=test_file_with_project.id,
+            version_number=v2.version_number,
+            user_id="test-user",
+        )
+        assert file.content == "章节开头\n***\n结尾\n"
+
+    def test_create_apply_diff_fuzz_roundtrip(self, file_version_service):
+        """_create_diff -> _apply_diff must round-trip arbitrary content."""
+        rng = random.Random(20260726)
+        line_pool = [
+            "---",
+            "----",
+            "+++",
+            "++++",
+            "--",
+            "++",
+            "-",
+            "+",
+            "-- 注释风格",
+            "++重点",
+            "@@ -1,2 +1,2 @@",
+            "@@",
+            "普通的一行",
+            "another plain line",
+            "",
+            "  缩进行",
+            "***",
+        ]
+
+        for _ in range(100):
+            old_lines = [rng.choice(line_pool) for _ in range(rng.randint(0, 15))]
+            # Mutate: random deletions, insertions, replacements
+            new_lines = list(old_lines)
+            for _ in range(rng.randint(0, 6)):
+                op = rng.choice(["insert", "delete", "replace"])
+                if op == "insert":
+                    new_lines.insert(rng.randint(0, len(new_lines)), rng.choice(line_pool))
+                elif op == "delete" and new_lines:
+                    new_lines.pop(rng.randrange(len(new_lines)))
+                elif op == "replace" and new_lines:
+                    new_lines[rng.randrange(len(new_lines))] = rng.choice(line_pool)
+
+            old_content = "\n".join(old_lines) + ("\n" if rng.random() < 0.7 else "")
+            new_content = "\n".join(new_lines) + ("\n" if rng.random() < 0.7 else "")
+
+            diff = file_version_service._create_diff(old_content, new_content)
+            result = file_version_service._apply_diff(old_content, diff)
+            assert result == new_content, (
+                f"Round-trip failed:\nold: {old_content!r}\n"
+                f"new: {new_content!r}\ngot: {result!r}"
             )
 
 

--- a/apps/server/tests/test_tool_context.py
+++ b/apps/server/tests/test_tool_context.py
@@ -2,6 +2,8 @@
 Unit tests for ToolContext with contextvars isolation.
 """
 
+import asyncio
+
 import pytest
 
 from agent.tools.mcp_tools import ToolContext
@@ -85,6 +87,81 @@ class TestToolContextPendingFile:
 
         # 待写入文件应该被清除
         assert ToolContext.has_pending_empty_file() is False
+
+
+class TestToolContextCrossTask:
+    """待写入空文件标记必须跨 asyncio 任务可见。
+
+    openai-agents SDK 为 run loop 和每次 function tool 调用各包一层
+    asyncio.create_task，create_task 只拷贝 contextvars 快照，因此标记
+    不能依赖子任务里的 ContextVar 重绑定传递。
+    """
+
+    @pytest.mark.asyncio
+    async def test_pending_flag_set_in_nested_task_visible_in_parent(self):
+        """两层嵌套子任务（模拟 SDK run-loop task + tool task）里设置的标记，父上下文必须可见"""
+        ToolContext.set_context(None, "user-1", "project-1", None)
+        try:
+
+            async def tool_task():
+                ToolContext.set_pending_empty_file("file-1", "第1章.md")
+
+            async def run_loop_task():
+                await asyncio.create_task(tool_task())
+
+            await asyncio.create_task(run_loop_task())
+
+            assert ToolContext.has_pending_empty_file() is True
+            pending = ToolContext.get_pending_empty_file()
+            assert pending == {"file_id": "file-1", "title": "第1章.md"}
+        finally:
+            ToolContext.clear_context()
+
+    @pytest.mark.asyncio
+    async def test_clear_in_parent_visible_in_later_child_task(self):
+        """父上下文清除标记后，后续子任务（如下一次 create_file 工具调用）必须读到已清除"""
+        ToolContext.set_context(None, "user-1", "project-1", None)
+        try:
+
+            async def set_task():
+                ToolContext.set_pending_empty_file("file-1", "第1章.md")
+
+            await asyncio.create_task(set_task())
+            assert ToolContext.has_pending_empty_file() is True
+
+            ToolContext.clear_pending_empty_file()
+
+            seen: list[bool] = []
+
+            async def read_task():
+                seen.append(ToolContext.has_pending_empty_file())
+
+            await asyncio.create_task(read_task())
+            assert seen == [False]
+            assert ToolContext.has_pending_empty_file() is False
+        finally:
+            ToolContext.clear_context()
+
+    @pytest.mark.asyncio
+    async def test_pending_flag_set_in_gather_subtask_visible_to_siblings_and_parent(self):
+        """asyncio.gather 子任务里设置的标记，兄弟任务与父上下文都必须可见"""
+        ToolContext.set_context(None, "user-1", "project-1", None)
+        try:
+            sibling_saw: list[bool] = []
+
+            async def setter():
+                ToolContext.set_pending_empty_file("file-a", "并行文件.md")
+
+            async def reader():
+                await asyncio.sleep(0.05)
+                sibling_saw.append(ToolContext.has_pending_empty_file())
+
+            await asyncio.gather(setter(), reader())
+
+            assert sibling_saw == [True]
+            assert ToolContext.has_pending_empty_file() is True
+        finally:
+            ToolContext.clear_context()
 
 
 class TestToolContextSession:

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -394,9 +394,11 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
   // Use the useChatStreaming hook for streaming UI state management
   const {
     streamRenderItems,
+    clearStreamItems,
     editProgress,
     setEditProgress,
     matchedSkills,
+    setMatchedSkills,
     getStreamCallbacks,
   } = useChatStreaming();
   const [suggestionDisplayState, setSuggestionDisplayState] = useState<SuggestionDisplayState>("loading");
@@ -1030,6 +1032,12 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
     setMessages([]);
     setFeedbackPendingMessageId(null);
     setEditProgress(null);
+    // 旧项目的流式渲染残留（半截正文/工具卡片/技能芯片/冲突）不能带进新项目会话：
+    // 旧流已被 useAgentStream 的项目切换 effect 中止，其 onComplete 永远不会执行，
+    // 所以必须在这里主动清空。
+    clearStreamItems();
+    setMatchedSkills([]);
+    reset();
     setAiSuggestions([]);
     setSuggestionDisplayState("loading");
     contextItemsRef.current = [];
@@ -1039,7 +1047,7 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
       const loadedMessages = await loadChatHistory(currentProjectId);
       await requestInitialSuggestions(currentProjectId, loadedMessages);
     })();
-  }, [currentProjectId, loadChatHistory, requestInitialSuggestions, setAiSuggestions, setEditProgress]); // 依赖 loadChatHistory
+  }, [currentProjectId, loadChatHistory, requestInitialSuggestions, setAiSuggestions, setEditProgress, clearStreamItems, setMatchedSkills, reset]); // 依赖 loadChatHistory
 
   // Auto-scroll to bottom when new messages arrive or streaming content meaningfully changes.
   // Coalesce scrolls in a single RAF to avoid completion-time jitter from multiple back-to-back
@@ -1307,6 +1315,9 @@ const ChatPanelComponent: React.FC<ChatPanelProps> = () => {
       await createNewSession(currentProjectId);
       setMessages([]);
       setFeedbackPendingMessageId(null);
+      // 上一轮若被取消/出错，流式渲染残留不会被 onComplete 清理，这里一并清空。
+      clearStreamItems();
+      setMatchedSkills([]);
       reset();
       await requestInitialSuggestions(currentProjectId, []);
     } catch (err) {

--- a/apps/web/src/components/MessageInput.tsx
+++ b/apps/web/src/components/MessageInput.tsx
@@ -330,6 +330,7 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [externalDraft]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
   const { attachedMaterials, removeMaterial } = useMaterialAttachment();
   const { quotes, removeQuote } = useTextQuote();
   const { pendingTrigger, consumeTrigger } = useSkillTrigger();
@@ -499,6 +500,17 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // IME 组字期间（拼音/日文输入法）按 Enter 只是确认候选词，不能触发发送等快捷键。
+    // Safari 会在 compositionend 之后才派发确认键的 keydown（此时 isComposing 已为
+    // false，但 keyCode 仍是 229），所以需要 composition 事件 + isComposing/keyCode 双重判断。
+    if (
+      isComposingRef.current ||
+      e.nativeEvent.isComposing ||
+      e.nativeEvent.keyCode === 229
+    ) {
+      return;
+    }
+
     // Handle skill menu navigation
     if (showSkillMenu && filteredSkills.length > 0) {
       if (e.key === "ArrowDown") {
@@ -885,6 +897,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
           value={input}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposingRef.current = false;
+          }}
           placeholder={displayPlaceholder}
           disabled={inputDisabled}
           className={`flex-1 bg-[hsl(var(--bg-tertiary))] border border-transparent rounded-lg text-sm text-[hsl(var(--text-primary))] placeholder-[hsl(var(--text-secondary)/0.5)] outline-none resize-none overflow-y-auto transition-all disabled:opacity-50 focus:border-[hsl(var(--accent-primary)/0.5)] focus:shadow-[inset_0_1px_2px_hsl(0_0%_0%_/_0.1),_0_0_0_2px_hsl(var(--accent-primary)/0.15)] ${

--- a/apps/web/src/components/MobileChatInput.tsx
+++ b/apps/web/src/components/MobileChatInput.tsx
@@ -197,6 +197,7 @@ export const MobileChatInput: React.FC<MobileChatInputProps> = ({
 }) => {
   const { t } = useTranslation(["chat", "common"]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
   const longPressTimerRef = useRef<number | null>(null);
   const isLongPressRef = useRef(false);
 
@@ -274,6 +275,17 @@ export const MobileChatInput: React.FC<MobileChatInputProps> = ({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // IME 组字期间（拼音/日文输入法）按 Enter 只是确认候选词，不能触发发送。
+    // Safari 会在 compositionend 之后才派发确认键的 keydown（此时 isComposing 已为
+    // false，但 keyCode 仍是 229），所以需要 composition 事件 + isComposing/keyCode 双重判断。
+    if (
+      isComposingRef.current ||
+      e.nativeEvent.isComposing ||
+      e.nativeEvent.keyCode === 229
+    ) {
+      return;
+    }
+
     // Enter sends message
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -470,6 +482,12 @@ export const MobileChatInput: React.FC<MobileChatInputProps> = ({
             value={input}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => {
+              isComposingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              isComposingRef.current = false;
+            }}
             placeholder={displayPlaceholder}
             disabled={disabled}
             className="flex-1 bg-[hsl(var(--bg-tertiary))] rounded-2xl px-4 py-3 text-base text-[hsl(var(--text-primary))] placeholder-[hsl(var(--text-secondary)/0.5)] outline-none resize-none overflow-y-auto transition-all disabled:opacity-50 focus:ring-2 focus:ring-[hsl(var(--accent-primary)/0.3)]"

--- a/apps/web/src/components/__tests__/ChatPanel.mount.test.tsx
+++ b/apps/web/src/components/__tests__/ChatPanel.mount.test.tsx
@@ -102,6 +102,7 @@ const streamCallbacks = {
 vi.mock('../../hooks/useChatStreaming', () => ({
   useChatStreaming: () => ({
     streamRenderItems: [],
+    clearStreamItems: vi.fn(),
     editProgress: null,
     setEditProgress: vi.fn(),
     aiSuggestions: [],
@@ -109,6 +110,7 @@ vi.mock('../../hooks/useChatStreaming', () => ({
     isRefreshingSuggestions: false,
     setIsRefreshingSuggestions: vi.fn(),
     matchedSkills: [],
+    setMatchedSkills: vi.fn(),
     getStreamCallbacks: vi.fn(() => streamCallbacks),
     clearIdleTimer: vi.fn(),
   }),

--- a/apps/web/src/components/__tests__/ChatPanel.projectSwitch.test.tsx
+++ b/apps/web/src/components/__tests__/ChatPanel.projectSwitch.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Regression tests: 项目切换时旧项目的流式渲染残留必须被清空。
+ *
+ * 旧流被 useAgentStream 的项目切换 effect 中止后，onComplete 永远不会执行，
+ * 因此 streamRenderItems / matchedSkills 只能由 ChatPanel 的项目切换 reset
+ * effect 主动清理，否则会被追加渲染进新项目的会话中。
+ *
+ * 本文件使用真实的 useChatStreaming（不 mock），只 mock useAgentStream 以便
+ * 直接驱动其回调向真实流式状态里注入渲染项。
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+
+// ChatPanel 被 React.memo 包裹且无 props，真实应用里靠 ProjectContext 变化触发
+// 重渲染；这里用可通知的外部 store 模拟 context 更新，绕过 memo 的 props 比较。
+const projectStore = vi.hoisted(() => {
+  const listeners = new Set<() => void>()
+  const store = {
+    currentProjectId: 'project-1',
+    setProjectId(id: string) {
+      store.currentProjectId = id
+      listeners.forEach((listener) => listener())
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+  return store
+})
+
+const mockAgentStreamState = vi.hoisted(() => ({
+  isStreaming: false,
+  isThinking: false,
+}))
+
+const capturedUseAgentStream = vi.hoisted(() => ({
+  options: null as Record<string, unknown> | null,
+}))
+
+const agentStreamReset = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string } | string) =>
+      typeof options === 'string' ? options : options?.defaultValue ?? key,
+  }),
+}))
+
+vi.mock('../../contexts/ProjectContext', () => ({
+  useProject: () => {
+    const currentProjectId = React.useSyncExternalStore(
+      (listener: () => void) => projectStore.subscribe(listener),
+      () => projectStore.currentProjectId
+    )
+    return {
+      currentProjectId,
+      selectedItem: null,
+      triggerFileTreeRefresh: vi.fn(),
+      triggerEditorRefresh: vi.fn(),
+      setSelectedItem: vi.fn(),
+      appendFileContent: vi.fn(),
+      finishFileStreaming: vi.fn(),
+      startFileStreaming: vi.fn(),
+      streamingFileId: null,
+      enterDiffReview: vi.fn(),
+    }
+  },
+}))
+
+vi.mock('../../contexts/MobileLayoutContext', () => ({
+  useMobileLayout: () => ({ isMobile: false }),
+}))
+
+vi.mock('../../contexts/MaterialAttachmentContext', () => ({
+  useMaterialAttachment: () => ({
+    attachedFileIds: [],
+    attachedLibraryMaterials: [],
+    clearMaterials: vi.fn(),
+  }),
+}))
+
+vi.mock('../../contexts/TextQuoteContext', () => ({
+  useTextQuote: () => ({
+    quotes: [],
+    clearQuotes: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useAgentStream', () => ({
+  useAgentStream: (_projectId: string, options?: Record<string, unknown>) => {
+    capturedUseAgentStream.options = options ?? null
+    return {
+      state: { conflicts: [] },
+      startStream: vi.fn(),
+      cancel: vi.fn(),
+      reset: agentStreamReset,
+      isStreaming: mockAgentStreamState.isStreaming,
+      isThinking: mockAgentStreamState.isThinking,
+      thinkingContent: '',
+      conflicts: [],
+      error: null,
+      errorCode: null,
+      sessionId: null,
+      sendSteeringMessage: vi.fn(),
+    }
+  },
+}))
+
+vi.mock('../../hooks/useDraftPersistence', () => ({
+  useDraftPersistence: () => ({
+    draft: '',
+    saveDraft: vi.fn(),
+    clearDraft: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/chatApi', () => ({
+  getRecentMessages: vi.fn(async () => []),
+  createNewSession: vi.fn(async () => ({ id: 'session-1' })),
+  submitMessageFeedback: vi.fn(),
+}))
+
+vi.mock('../../lib/agentApi', () => ({
+  fetchSuggestions: vi.fn(async () => []),
+}))
+
+vi.mock('../../lib/api', () => ({
+  fileVersionApi: {},
+  versionApi: {},
+}))
+
+const mockMessageList = vi.fn(() => <div data-testid="mock-message-list" />)
+const mockMessageInput = vi.fn(() => <div data-testid="mock-message-input" />)
+
+vi.mock('../MessageList', () => ({
+  MessageList: React.forwardRef((props: unknown, _ref) => mockMessageList(props)),
+}))
+
+vi.mock('../MessageInput', () => ({
+  MessageInput: (props: unknown) => mockMessageInput(props),
+}))
+
+vi.mock('../ToolResultCard', () => ({
+  ToolResultCard: () => <div data-testid="mock-tool-result-card" />,
+}))
+
+vi.mock('../ProjectStatusDialog', () => ({
+  ProjectStatusDialog: () => null,
+}))
+
+vi.mock('../subscription/QuotaBadge', () => ({
+  QuotaBadge: () => <div data-testid="mock-quota-badge" />,
+}))
+
+vi.mock('../../lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { ChatPanel } from '../ChatPanel'
+import { getRecentMessages } from '../../lib/chatApi'
+
+type StreamCallbackOptions = {
+  onThinking?: (message: string) => void
+  onSkillsMatched?: (
+    skills: Array<{ id: string; name: string; trigger: string; confidence: number }>
+  ) => void
+}
+
+const lastMessageListProps = () => {
+  const calls = mockMessageList.mock.calls as unknown as Array<
+    [{ streamRenderItems?: Array<{ content?: string }>; messages?: Array<{ content: string }> }]
+  >
+  return calls[calls.length - 1]?.[0]
+}
+
+const lastMessageInputProps = () => {
+  const calls = mockMessageInput.mock.calls as unknown as Array<
+    [{ matchedSkills?: Array<{ name: string }> }]
+  >
+  return calls[calls.length - 1]?.[0]
+}
+
+describe('ChatPanel project switch stream cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedUseAgentStream.options = null
+    projectStore.currentProjectId = 'project-1'
+    mockAgentStreamState.isStreaming = false
+    mockAgentStreamState.isThinking = false
+  })
+
+  it('clears leftover streamRenderItems and matchedSkills when switching projects', async () => {
+    // 项目 A：流式进行中，产生渲染残留
+    mockAgentStreamState.isStreaming = true
+    render(<ChatPanel />)
+
+    await waitFor(() => {
+      expect(capturedUseAgentStream.options).not.toBeNull()
+    })
+
+    const options = capturedUseAgentStream.options as StreamCallbackOptions
+    act(() => {
+      options.onThinking?.('旧项目残留内容')
+      options.onSkillsMatched?.([
+        { id: 'skill-1', name: '写作技能', trigger: '续写', confidence: 0.9 },
+      ])
+    })
+
+    await waitFor(() => {
+      const listProps = lastMessageListProps()
+      expect(listProps?.streamRenderItems).toHaveLength(1)
+      expect(listProps?.streamRenderItems?.[0]?.content).toBe('旧项目残留内容')
+    })
+    expect(lastMessageInputProps()?.matchedSkills).toHaveLength(1)
+
+    // 切换到项目 B：旧流被中止（onComplete 不会执行），新项目加载自己的历史
+    vi.mocked(getRecentMessages).mockResolvedValueOnce([
+      {
+        id: 'msg-b1',
+        session_id: 'session-b',
+        role: 'assistant',
+        content: '项目B的历史消息',
+        tool_calls: null,
+        created_at: '2026-03-01T12:00:00Z',
+        metadata: null,
+      },
+    ] as never)
+    mockAgentStreamState.isStreaming = false
+    act(() => {
+      projectStore.setProjectId('project-2')
+    })
+
+    await waitFor(() => {
+      const listProps = lastMessageListProps()
+      expect(listProps?.messages?.[0]?.content).toBe('项目B的历史消息')
+    })
+
+    // 旧项目的流式残留不能渲染进新项目会话
+    const listProps = lastMessageListProps()
+    expect(listProps?.streamRenderItems).toHaveLength(0)
+    expect(lastMessageInputProps()?.matchedSkills).toHaveLength(0)
+    // conflicts 等 useAgentStream 内部状态通过 reset() 一并复位
+    expect(agentStreamReset).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/__tests__/MessageInput.test.tsx
+++ b/apps/web/src/components/__tests__/MessageInput.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MessageInput } from '../MessageInput'
 import { skillsApi } from '../../lib/api'
@@ -566,6 +566,77 @@ describe('MessageInput', () => {
       expect(
         screen.queryByPlaceholderText('chat:input.steerPlaceholder')
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('IME composition (中文/日文输入法)', () => {
+    it('does not send when Enter keydown carries isComposing (Chrome/Edge 确认候选词)', () => {
+      const onSend = vi.fn()
+      render(<MessageInput {...defaultProps} onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('chat:input.placeholder')
+      fireEvent.change(textarea, { target: { value: 'ni hao' } })
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true })
+
+      expect(onSend).not.toHaveBeenCalled()
+      expect(textarea).toHaveValue('ni hao')
+    })
+
+    it('does not send on Enter between compositionstart and compositionend', () => {
+      const onSend = vi.fn()
+      render(<MessageInput {...defaultProps} onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('chat:input.placeholder')
+      fireEvent.compositionStart(textarea)
+      fireEvent.change(textarea, { target: { value: 'nihao' } })
+      fireEvent.keyDown(textarea, { key: 'Enter' })
+
+      expect(onSend).not.toHaveBeenCalled()
+    })
+
+    it('does not send when the confirming Enter arrives after compositionend with keyCode 229 (Safari)', () => {
+      const onSend = vi.fn()
+      render(<MessageInput {...defaultProps} onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('chat:input.placeholder')
+      fireEvent.compositionStart(textarea)
+      fireEvent.change(textarea, { target: { value: '你好' } })
+      fireEvent.compositionEnd(textarea)
+      fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 229 })
+
+      expect(onSend).not.toHaveBeenCalled()
+    })
+
+    it('sends normally on Enter after composition has ended', () => {
+      const onSend = vi.fn()
+      render(<MessageInput {...defaultProps} onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('chat:input.placeholder')
+      fireEvent.compositionStart(textarea)
+      fireEvent.change(textarea, { target: { value: '你好' } })
+      fireEvent.compositionEnd(textarea)
+      fireEvent.keyDown(textarea, { key: 'Enter' })
+
+      expect(onSend).toHaveBeenCalledWith('你好')
+    })
+
+    it('does not steer when Enter keydown carries isComposing while generating', () => {
+      const onSteer = vi.fn()
+      render(
+        <MessageInput
+          {...defaultProps}
+          sendDisabled={true}
+          onCancel={vi.fn()}
+          onSteer={onSteer}
+          canSteer={true}
+        />
+      )
+
+      const textarea = screen.getByPlaceholderText('chat:input.steerPlaceholder')
+      fireEvent.change(textarea, { target: { value: 'jia yi duan xuan nian' } })
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true })
+
+      expect(onSteer).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/web/src/components/__tests__/MobileChatInput.test.tsx
+++ b/apps/web/src/components/__tests__/MobileChatInput.test.tsx
@@ -203,4 +203,56 @@ describe('MobileChatInput', () => {
     expect(removeMaterial).toHaveBeenCalledWith('material-1')
     expect(removeQuote).toHaveBeenCalledWith('quote-1')
   })
+
+  describe('IME composition (中文/日文输入法)', () => {
+    it('does not send when Enter keydown carries isComposing (Chrome/Edge 确认候选词)', () => {
+      const onSend = vi.fn()
+      render(<MobileChatInput onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('Type a message')
+      fireEvent.change(textarea, { target: { value: 'ni hao' } })
+      fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true })
+
+      expect(onSend).not.toHaveBeenCalled()
+      expect(textarea).toHaveValue('ni hao')
+    })
+
+    it('does not send on Enter between compositionstart and compositionend', () => {
+      const onSend = vi.fn()
+      render(<MobileChatInput onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('Type a message')
+      fireEvent.compositionStart(textarea)
+      fireEvent.change(textarea, { target: { value: 'nihao' } })
+      fireEvent.keyDown(textarea, { key: 'Enter' })
+
+      expect(onSend).not.toHaveBeenCalled()
+    })
+
+    it('does not send when the confirming Enter arrives after compositionend with keyCode 229 (Safari)', () => {
+      const onSend = vi.fn()
+      render(<MobileChatInput onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('Type a message')
+      fireEvent.compositionStart(textarea)
+      fireEvent.change(textarea, { target: { value: '你好' } })
+      fireEvent.compositionEnd(textarea)
+      fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 229 })
+
+      expect(onSend).not.toHaveBeenCalled()
+    })
+
+    it('sends normally on Enter after composition has ended', () => {
+      const onSend = vi.fn()
+      render(<MobileChatInput onSend={onSend} />)
+
+      const textarea = screen.getByPlaceholderText('Type a message')
+      fireEvent.compositionStart(textarea)
+      fireEvent.change(textarea, { target: { value: '你好' } })
+      fireEvent.compositionEnd(textarea)
+      fireEvent.keyDown(textarea, { key: 'Enter' })
+
+      expect(onSend).toHaveBeenCalledWith('你好')
+    })
+  })
 })


### PR DESCRIPTION
## 背景

对 `apps/server/agent` 子系统（约 2.4 万行）与前端流式链路做了一轮多智能体深度审查：9 个维度并行深读代码，29 个原始 findings 去重后逐一对抗验证（高危项采用「可达性 + 影响面」双视角，全票才确认），最终确认 **23 个真实缺陷**、反驳 1 个误报。本 PR 修复全部 23 项，并对本批改动再做了一轮独立 review，回修其中引入的 5 个新问题。

## 修复内容

### 数据丢失 / 内容损坏

| 缺陷 | 位置 |
|---|---|
| 版本 diff 重放把以 `--`/`++` 开头的内容行误判为 diff 文件头，版本重建/对比/回滚返回损坏内容（Markdown `---` 分隔线场景必现，AI 生成大纲中极常见）——版本历史这张「AI 编辑安全网」自身在损坏数据 | `file_version_service.py` |
| SQLite 下 `edit_file`/`update_file` 读到共享 session 身份映射中的陈旧 File 对象（隔着完整 LLM 往返，数十秒到数分钟），静默覆盖用户在此期间的并发保存 | `file_ops/edit.py`、`crud.py` |
| 前端取消/断连中止流后，整轮对话（用户消息 + 已完成 tool_calls + 已消费 steering）不写入聊天历史 | `service.py` |
| 正文中反引号包裹的 `</file>` 提前截断文件，剩余正文与真实结束标记泄漏进聊天流 | `stream_processor.py` |
| 并发编辑同一文件时版本链头内容与正文逆序，「恢复最新版本」会写回旧内容 | `file_ops/edit.py`、`crud.py` |

修法要点：diff 改为按 `@@` hunk 结构解析而非对任意行做 `startswith` 猜测；陈旧读取改为 `populate_existing` 强制取最新行；取消路径改为 `shield` + 独立 session 落库后再传播 `CancelledError`；版本快照纳入持锁区间（PG 用 `FOR NO KEY UPDATE` 避免与版本表外键的 `KEY SHARE` 互斥挂起，SQLite 用按 file_id 分片的进程内锁）。

### ContextVar 跨任务失效（一个根因，三处症状）

openai-agents SDK 用 `asyncio.create_task` 执行每个 function tool，`create_task` 只拷贝 contextvars，子任务内的写入不回传父上下文。因此 `create_file` 里的 pending-empty-file 标记全部写进随任务销毁的副本，导致：

- **空文件纠偏循环是死代码**——「创建了空文件但未完成 `<file>` 写入 → 重跑 writer 补写」的整套 `MAX_FILE_CORRECTION_ATTEMPTS` 机制从未生效
- **连续空文件守卫失效**——第二次 `create_file` 不被拦截，先前已流出的正文被静默丢弃
- **`parallel_execute` 子任务标记丢失**——空文件上报 `completed`

改为把状态放进请求级 context dict 持有的可变对象（所有子任务上下文副本引用同一实例，`dict()` 浅拷贝保留引用），一处修复三处症状。原单元测试因在同一上下文内 set/get 而全绿，掩盖了该问题——新增测试真实跨两层 `create_task` 与 `gather` 验证。

### Steering

- **运行中到达的引导消息永不被消费**：队列唯一消费点在每次迭代*开始前*，单迭代 workflow（fast 模式 / 多数 quick 请求）里轮询发生在任何生成之前；流结束时 `finally` 还会无条件删除未消费消息，而 API 早已返回 `queued: true`。现在 runner 事件循环在工具边界新增消费点，且 cleanup 前 drain 并持久化到聊天历史
- **并发 run 共享 session 级队列键**，先结束者删掉他人正在使用的队列（导致 steer 返回 404）：改为 run 级引用计数

### 权限

`edit_file`/`delete_file` 只校验「当前用户拥有该文件所在项目」，从不与当前会话 project_id 比对（专为此设计的 `check_file_ownership` 在生产路径零调用）。同一用户的其他项目完全不设防，且根文件夹 id 可预测（`{project_id}-draft-folder`）——素材文件中的注入文本可诱导递归删除另一项目的草稿树。现在生产分发路径统一复用 `check_file_ownership`。

### 会话 / 预算 / 其它

- Postgres 部分唯一索引使重激活非活跃会话必然 `IntegrityError`（SQLAlchemy 按主键排序发 UPDATE，激活先于去激活）——旧标签页发消息**确定性**失败直到刷新
- SSE 长流全程持有 `idle in transaction` 连接，30 个并发长流即可占满连接池（10+20）导致整站超时
- prompt token 台账重复计费 skill catalog/reference 与组装上下文；thinking 幽灵 token 占据历史预算（计费含 thinking 但发送时丢弃，实际可达预算的 1/10）；CJK Ext-B 区间字面量 `\u` 转义错误（西文标点被判为 CJK，Ext-B 汉字判不中）；parent 大纲 → CRITICAL 规则因提前返回不可达
- `query_files` 的 limit/offset 逐类型独立应用（返回量超声明上限、翻页错位）；chat messages 端点按升序取前 N 条使最新消息结构性不可达
- 前端：中文 IME 按 Enter 确认候选词误发送消息（面向中文作者的核心输入路径）；项目切换后旧项目的流式内容渲染进新项目会话

## 回修（对本批改动再做一轮 review 后发现）

第二轮独立审查（5 维度 + 对抗验证）确认并修复了本批修复自身引入的 5 个问题：

- 父大纲升到 CRITICAL 后按相关度**压过用户显式附加的文件**，紧预算下附加文件被挤出上下文（54 组场景实测 38 组变差）
- `WAITING_START` 的歧义开始标记缺 `at_eof` 复扫：叙述含未闭合围栏时整章正文带原始 `<file>` 标记泄漏进对话、文件留空、生成全程零 SSE
- 取消恰好落在 `save_messages` 的 `to_thread` 期间 → 整轮历史**重复落库**
- 空文件纠偏循环转活后，对已用 `edit_file` 写完正文的文件误触发重跑（正文写两遍）
- `create_file` 对 `file_type=folder` 也置 pending 标记，硬阻断同一轮后续建档（分卷场景）

另有 4 项经验证判定为**非阻塞**，未在本 PR 处理：软删除文件在流式落盘时被拒（既有行为权衡）、PG commit 失败留下幽灵版本、多类型 `query_files` 每类型可见条数下降且无 `has_more` 信号、并发 run 的兜底 drain 可取走他人 steering（session 级键的固有语义）。

## 验证

- **后端**：2536 passed / 14 skipped / **0 failed**（skip 全为既有门禁：需真实 Postgres 或 real-LLM key）
- **前端**：2204 passed / 1 skipped（既有）/ **0 failed**
- **静态检查**：`tsc --noEmit`、eslint、ruff 全部干净
- **防假完成**：所有新增回归测试已在 main 的独立 worktree 上确认能**复现原 bug**（修复前失败、修复后通过），而非事后补写的空转测试

## 已知约束（非缺陷）

1. steering 落在**最后一个迭代的纯文本生成期间**仍无法在本请求内生效——openai-agents 不支持向进行中的 run 注入消息，只能持久化到下一轮
2. SQLite 的版本快照同序保证依赖进程内锁，仅覆盖单进程部署（默认形态）
3. Postgres 行锁语义本机无 PG 实例未实测（相关测试为既有 Postgres 门禁 skip），依据是 PG 行锁兼容矩阵
4. `keyCode 229` 守卫在部分 Android 软键盘上会使物理 Enter 无法发送（该端主路径是发送按钮）

🤖 Generated with [Claude Code](https://claude.com/claude-code)