### PR TITLE
docs: migrate repository namespace to zenstory-ai

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question / Discussion
-    url: https://github.com/worldwonderer/zenstory/discussions
+    url: https://github.com/zenstory-ai/zenstory/discussions
     about: Ask questions and discuss ideas with the community.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **对话即创作 — AI Agent 驱动的商业级小说写作工作台**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![GitHub Stars](https://img.shields.io/github/stars/worldwonderer/zenstory?style=social)](https://github.com/worldwonderer/zenstory)
+[![GitHub Stars](https://img.shields.io/github/stars/zenstory-ai/zenstory?style=social)](https://github.com/zenstory-ai/zenstory)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fzenstory.ai&label=zenstory.ai)](https://zenstory.ai/)
 
 ZenStory 让 AI Agent 直接操作你的创作文件——建角色卡、拆参考素材、规划大纲、逐章写作——全部在一次对话里完成。
@@ -234,8 +234,8 @@ Monorepo：React 前端（`apps/web`）+ FastAPI 后端（`apps/server`），文
 
 欢迎通过以下方式参与：
 
-- [提交 Bug](https://github.com/worldwonderer/zenstory/issues/new?template=bug_report.md)
-- [功能建议](https://github.com/worldwonderer/zenstory/issues/new?template=feature_request.md)
+- [提交 Bug](https://github.com/zenstory-ai/zenstory/issues/new?template=bug_report.md)
+- [功能建议](https://github.com/zenstory-ai/zenstory/issues/new?template=feature_request.md)
 - 提交 Pull Request
 
 请阅读 [CONTRIBUTING.md](CONTRIBUTING.md) 了解贡献流程。

--- a/README_EN.md
+++ b/README_EN.md
@@ -7,7 +7,7 @@
 **Where Conversation Meets Creation — The AI Agent-Powered Commercial Novel-Writing Workbench**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![GitHub Stars](https://img.shields.io/github/stars/worldwonderer/zenstory?style=social)](https://github.com/worldwonderer/zenstory)
+[![GitHub Stars](https://img.shields.io/github/stars/zenstory-ai/zenstory?style=social)](https://github.com/zenstory-ai/zenstory)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fzenstory.ai&label=zenstory.ai)](https://zenstory.ai/)
 ![React](https://img.shields.io/badge/React_19-61DAFB?logo=react&logoColor=black)
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)
@@ -319,8 +319,8 @@ zenstory/
 
 Contributions are welcome!
 
-- [Report a Bug](https://github.com/worldwonderer/zenstory/issues/new?template=bug_report.md)
-- [Request a Feature](https://github.com/worldwonderer/zenstory/issues/new?template=feature_request.md)
+- [Report a Bug](https://github.com/zenstory-ai/zenstory/issues/new?template=bug_report.md)
+- [Request a Feature](https://github.com/zenstory-ai/zenstory/issues/new?template=feature_request.md)
 - Submit a Pull Request
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary
- update canonical repository links from `worldwonderer/zenstory` to `zenstory-ai/zenstory`
- update the issue template contact link
- preserve personal author/developer identities and all application/deployment configuration

## Scope
Documentation/community-health metadata only. No runtime code, dependency, workflow, Vercel, Railway, or Codecov configuration changes.

## Validation
- `git diff --check`
- namespace occurrence audit: only the three intended canonical repository references changed
- local backend lint passed
- local frontend: 2,242 passed, 1 skipped; coverage 82.64%; lint passed
- steering queue isolated verification with Redis unset: 51 passed
- full `gate:lite` additionally recorded a pre-existing local Redis/backend-selection test interaction (5 failures out of 2,965 collected); the migration patch does not touch that code or test configuration
- pre-transfer S0/S1 repository snapshot comparison passed with owner change as the only allowed delta
