### PR TITLE
perf(server): reduce Railway memory usage

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -40,4 +40,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"
 
 # Start application
-CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port 8080 --workers ${WEB_CONCURRENCY:-3} --timeout-keep-alive 300 --timeout-worker-healthcheck 600"]
+CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port 8080 --workers ${WEB_CONCURRENCY:-1} --timeout-keep-alive 300 --timeout-worker-healthcheck 600"]

--- a/apps/server/agent/tools/file_ops/crud.py
+++ b/apps/server/agent/tools/file_ops/crud.py
@@ -1171,9 +1171,8 @@ class FileCRUD:
     ) -> None:
         """Fire-and-forget vector index upsert (do not block)."""
         try:
-            from services.llama_index import schedule_index_upsert
-
             from agent.tools.mcp_tools import ToolContext
+            from services.llama_index import schedule_index_upsert
 
             metadata = extra_metadata or {}
             if file.file_metadata:
@@ -1199,9 +1198,8 @@ class FileCRUD:
     def _schedule_index_delete(self, files: list[File]) -> None:
         """Fire-and-forget vector index delete (do not block)."""
         try:
-            from services.llama_index import schedule_index_delete
-
             from agent.tools.mcp_tools import ToolContext
+            from services.llama_index import schedule_index_delete
 
             user_id = ToolContext._get_context().get("user_id")
 

--- a/apps/server/api/files.py
+++ b/apps/server/api/files.py
@@ -644,10 +644,10 @@ def get_files(
 
 def _rebuild_vector_index_task(project_id: str) -> None:
     """Background task: rebuild vector index for a project."""
-    from services.llama_index import get_llama_index_service
     from sqlmodel import Session
 
     from database import sync_engine
+    from services.llama_index import get_llama_index_service
 
     with Session(sync_engine) as s:
         svc = get_llama_index_service()

--- a/apps/server/railway.toml
+++ b/apps/server/railway.toml
@@ -6,7 +6,7 @@ dockerfilePath = "Dockerfile"
 healthcheckPath = "/health"
 healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
-startCommand = "/bin/sh -c \"exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --workers ${WEB_CONCURRENCY:-3} --timeout-keep-alive 300 --timeout-worker-healthcheck 600\""
+startCommand = "/bin/sh -c \"exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --workers ${WEB_CONCURRENCY:-1} --timeout-keep-alive 300 --timeout-worker-healthcheck 600\""
 
 [deploy.healthcheck]
 path = "/health"

--- a/apps/server/services/__init__.py
+++ b/apps/server/services/__init__.py
@@ -60,12 +60,6 @@ from .infra.redis_client import (
     set_resend_cooldown,
     store_verification_code,
 )
-from .infra.vector_search_service import (
-    LlamaIndexService,
-    get_llama_index_service,
-    schedule_index_delete,
-    schedule_index_upsert,
-)
 
 # Create backward-compatible module aliases for old imports
 # This allows code like `from services.auth import ...` to still work
@@ -75,8 +69,26 @@ sys.modules['services.file_version'] = import_module('.features.file_version_ser
 sys.modules['services.version'] = import_module('.features.snapshot_service', package='services')
 sys.modules['services.export_service'] = import_module('.features.export_service', package='services')
 sys.modules['services.email_service'] = import_module('.infra.email_client', package='services')
-sys.modules['services.llama_index'] = import_module('.infra.vector_search_service', package='services')
 sys.modules['services.redis_client'] = import_module('.infra.redis_client', package='services')
+
+
+_VECTOR_EXPORTS = {
+    "LlamaIndexService",
+    "get_llama_index_service",
+    "schedule_index_delete",
+    "schedule_index_upsert",
+}
+
+
+def __getattr__(name: str):
+    """Load the optional vector stack only when a vector export is requested."""
+    if name not in _VECTOR_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module('.infra.vector_search_service', package=__name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     # Auth service

--- a/apps/server/services/llama_index.py
+++ b/apps/server/services/llama_index.py
@@ -1,0 +1,15 @@
+"""Backward-compatible, lazy entry point for the vector search service."""
+
+from .infra.vector_search_service import (
+    LlamaIndexService,
+    get_llama_index_service,
+    schedule_index_delete,
+    schedule_index_upsert,
+)
+
+__all__ = [
+    "LlamaIndexService",
+    "get_llama_index_service",
+    "schedule_index_delete",
+    "schedule_index_upsert",
+]

--- a/apps/server/tests/test_deployment_memory.py
+++ b/apps/server/tests/test_deployment_memory.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SERVER_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_isolated_import(source: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SERVER_ROOT)
+    return subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=SERVER_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_production_server_defaults_to_one_worker():
+    railway_config = (SERVER_ROOT / "railway.toml").read_text()
+    dockerfile = (SERVER_ROOT / "Dockerfile").read_text()
+
+    assert "${WEB_CONCURRENCY:-1}" in railway_config
+    assert "${WEB_CONCURRENCY:-1}" in dockerfile
+    assert "${WEB_CONCURRENCY:-3}" not in railway_config
+    assert "${WEB_CONCURRENCY:-3}" not in dockerfile
+
+
+def test_auth_import_does_not_load_vector_stack():
+    result = _run_isolated_import(
+        """
+import sys
+import services.auth
+
+unexpected = [
+    name
+    for name in (
+        "services.infra.vector_search_service",
+        "services.llama_index",
+        "chromadb",
+        "llama_index.core",
+    )
+    if name in sys.modules
+]
+if unexpected:
+    raise SystemExit(f"unexpected eager imports: {unexpected}")
+"""
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_legacy_llama_index_imports_remain_available():
+    result = _run_isolated_import(
+        """
+from services import LlamaIndexService as package_export
+from services.llama_index import (
+    LlamaIndexService,
+    get_llama_index_service,
+    schedule_index_delete,
+    schedule_index_upsert,
+)
+
+assert package_export is LlamaIndexService
+assert callable(get_llama_index_service)
+assert callable(schedule_index_delete)
+assert callable(schedule_index_upsert)
+"""
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary
- default the production API to one Uvicorn worker instead of three
- stop the `services` compatibility package from eagerly importing ChromaDB/LlamaIndex
- preserve `services.llama_index` and package-level vector exports through lazy compatibility shims
- add regression coverage for deployment concurrency and import behavior

## Memory evidence
- Railway before: ~847.6 MB current memory
- local production-shaped smoke after: ~150 MB RSS with one process
- Railway direct pre-validation after: ~147.3 MB current memory

## Validation
- `2955 passed, 14 skipped` (full server pytest suite)
- `245 passed, 3 skipped` (affected auth/vector/API suites)
- Ruff passes for all changed Python files
- local and Railway health checks pass
- OpenAPI still exposes 164 routes including vector search

The direct Railway upload was only a pre-validation. Final production verification will use the deployment triggered after this PR merges.
